### PR TITLE
Add lifted successor generator based on enumerating all maximum cliques

### DIFF
--- a/driver/arguments.py
+++ b/driver/arguments.py
@@ -34,7 +34,9 @@ SUCCESSOR_GENERATOR_CHOICES = ['yannakakis',
                                'join',
                                'random_join',
                                'ordered_join',
-                               'full_reducer']
+                               'full_reducer',
+                               'clique_bk',
+                               'clique_kckp']
 
 
 def parse_options():

--- a/src/search/CMakeLists.txt
+++ b/src/search/CMakeLists.txt
@@ -66,6 +66,9 @@ add_executable(search
         utils.cc utils.h
         successor_generators/random_successor.h successor_generators/random_successor.cc
         successor_generators/yannakakis.cc successor_generators/yannakakis.h
+        successor_generators/clique_successor_generator.cc successor_generators/clique_successor_generator_apply.cc successor_generators/clique_successor_generator.h
+        successor_generators/clique_bron_kerbosch.cc successor_generators/clique_bron_kerbosch.h
+        successor_generators/clique_help_functions.cc successor_generators/clique_help_functions.h
         database/project.cc database/project.h
         utils/segmented_vector.h
         states/extensional_states.cc states/extensional_states.h
@@ -81,6 +84,7 @@ add_executable(search
         utils/timer.cc utils/timer.h
         algorithms/int_hash_set.h
         algorithms/dynamic_bitset.h
+        algorithms/kpkc.cc algorithms/kpkc.h
         search_statistics.cc search_statistics.h
         options.h open_lists/greedy_open_list.h
         search_engines/breadth_first_width_search.cc search_engines/breadth_first_width_search.h

--- a/src/search/action_schema.h
+++ b/src/search/action_schema.h
@@ -89,6 +89,26 @@ public:
         return parameters.empty();
     }
 
+    bool operator<(const ActionSchema& other) const {
+        return index < other.index;
+    }
+
+    bool operator==(const ActionSchema& other) const {
+        return index == other.index;
+    }
+
+    bool operator!=(const ActionSchema& other) const {
+        return index != other.index;
+    }
 };
+
+namespace std {
+template <>
+struct hash<ActionSchema> {
+    size_t operator()(const ActionSchema &action) const {
+        return hash<int>()(action.get_index());
+    }
+};
+}  // namespace std
 
 #endif //SEARCH_ACTION_SCHEMA_H

--- a/src/search/algorithms/kpkc.cc
+++ b/src/search/algorithms/kpkc.cc
@@ -1,0 +1,114 @@
+#include "kpkc.h"
+
+namespace algorithms {
+
+bool find_all_k_cliques_in_k_partite_graph_helper(const std::vector<boost::dynamic_bitset<>> &adjacency_matrix,
+                                                  const std::vector<std::vector<size_t>> &partitions,
+                                                  std::vector<boost::dynamic_bitset<>> &compatible_vertices,
+                                                  boost::dynamic_bitset<> &partition_bits,
+                                                  boost::dynamic_bitset<> &not_partition_bits,
+                                                  std::vector<uint32_t> &partial_solution,
+                                                  std::vector<std::vector<uint32_t>> &out_cliques) {
+    size_t k = partitions.size();
+    size_t best_set_bits = std::numeric_limits<size_t>::max();
+    size_t best_partition = std::numeric_limits<size_t>::max();
+
+    // Find the best partition to work with
+    for (size_t partition = 0; partition < k; ++partition) {
+        const auto num_set_bits = compatible_vertices[partition].count();
+
+        if (not_partition_bits[partition] && (num_set_bits < best_set_bits)) {
+            best_set_bits = num_set_bits;
+            best_partition = partition;
+        }
+    }
+
+    size_t adjacent_index = compatible_vertices[best_partition].find_first();
+
+    // Iterate through compatible vertices in the best partition
+    while (adjacent_index < compatible_vertices[best_partition].size()) {
+        size_t vertex = partitions[best_partition][adjacent_index];
+        compatible_vertices[best_partition][adjacent_index] = 0;
+        partial_solution.push_back(static_cast<uint32_t>(vertex));
+
+        if (partial_solution.size() == k) {
+            out_cliques.push_back(partial_solution);
+        }
+        else {
+            // Update compatible vertices for the next recursion
+            std::vector<boost::dynamic_bitset<>> compatible_vertices_next = compatible_vertices;
+            size_t offset = 0;
+            for (size_t partition = 0; partition < k; ++partition) {
+                const auto partition_size = compatible_vertices_next[partition].size();
+                if (not_partition_bits[partition]) {
+                    for (size_t index = 0; index < partition_size; ++index) {
+                        compatible_vertices_next[partition][index] &=
+                            adjacency_matrix[vertex][index + offset];
+                    }
+                }
+                offset += partition_size;
+            }
+
+            partition_bits[best_partition] = 1;
+            not_partition_bits[best_partition] = 0;
+
+            size_t possible_additions = 0;
+            for (size_t partition = 0; partition < k; ++partition) {
+                if (not_partition_bits[partition] && compatible_vertices[partition].any()) {
+                    ++possible_additions;
+                }
+            }
+
+            if ((partial_solution.size() + possible_additions) == k) {
+                if (!find_all_k_cliques_in_k_partite_graph_helper(adjacency_matrix,
+                                                                  partitions,
+                                                                  compatible_vertices_next,
+                                                                  partition_bits,
+                                                                  not_partition_bits,
+                                                                  partial_solution,
+                                                                  out_cliques)) {
+                    return false;
+                }
+            }
+
+            partition_bits[best_partition] = 0;
+            not_partition_bits[best_partition] = 1;
+        }
+
+        partial_solution.pop_back();
+        adjacent_index = compatible_vertices[best_partition].find_next(adjacent_index);
+    }
+
+    return true;
+}
+
+bool find_all_k_cliques_in_k_partite_graph(const std::vector<boost::dynamic_bitset<>> &adjacency_matrix,
+                                           const std::vector<std::vector<size_t>> &partitions,
+                                           std::vector<std::vector<uint32_t>> &out_cliques) {
+    std::vector<boost::dynamic_bitset<>> compatible_vertices;
+
+    for (std::size_t index = 0; index < partitions.size(); ++index) {
+        boost::dynamic_bitset<> bitset(partitions[index].size());
+        bitset.set();
+        compatible_vertices.push_back(std::move(bitset));
+    }
+
+    const size_t k = partitions.size();
+    boost::dynamic_bitset<> partition_bits(k);
+    boost::dynamic_bitset<> not_partition_bits(k);
+    partition_bits.reset();
+    not_partition_bits.set();
+    std::vector<uint32_t> partial_solution;
+
+    const auto finished = find_all_k_cliques_in_k_partite_graph_helper(adjacency_matrix,
+                                                                       partitions,
+                                                                       compatible_vertices,
+                                                                       partition_bits,
+                                                                       not_partition_bits,
+                                                                       partial_solution,
+                                                                       out_cliques);
+
+    return finished;
+}
+
+}  // namespace algorithms

--- a/src/search/algorithms/kpkc.h
+++ b/src/search/algorithms/kpkc.h
@@ -1,0 +1,16 @@
+#if !defined(ALGORITHMS_KPKC_HPP_)
+#define ALGORITHMS_KPKC_HPP_
+
+#include <boost/dynamic_bitset.hpp>
+#include <chrono>
+#include <iostream>
+#include <limits>
+#include <vector>
+
+namespace algorithms {
+bool find_all_k_cliques_in_k_partite_graph(const std::vector<boost::dynamic_bitset<>> &adjacency_matrix,
+                                           const std::vector<std::vector<size_t>> &partitions,
+                                           std::vector<std::vector<uint32_t>> &out_cliques);
+}  // namespace algorithms
+
+#endif  // ALGORITHMS_KPKC_HPP_

--- a/src/search/object.h
+++ b/src/search/object.h
@@ -21,6 +21,26 @@ public:
 
     const std::vector<int> &get_types() const { return types; }
 
+    bool operator<(const Object& other) const {
+      return index < other.index;
+    }
+
+    bool operator==(const Object& other) const {
+      return index == other.index;
+    }
+
+    bool operator!=(const Object& other) const {
+      return index != other.index;
+    }
 };
+
+namespace std {
+template <>
+struct hash<Object> {
+    size_t operator()(const Object &object) const {
+        return hash<int>()(object.get_index());
+    }
+};
+}  // namespace std
 
 #endif // SEARCH_OBJECT_H

--- a/src/search/search_engines/astar_search.cc
+++ b/src/search/search_engines/astar_search.cc
@@ -21,6 +21,7 @@ utils::ExitCode AStarSearch<PackedStateT>::search(const Task &task,
 {
     cout << "Starting greedy best first search" << endl;
     clock_t timer_start = clock();
+    const auto action_schemas = task.get_action_schemas();
     StatePackerT packer(task);
 
     GreedyOpenList queue;
@@ -67,37 +68,34 @@ utils::ExitCode AStarSearch<PackedStateT>::search(const Task &task,
         DBState state = packer.unpack(space.get_state(sid));
         if (check_goal(task, generator, timer_start, state, node, space)) return utils::ExitCode::SUCCESS;
 
-        // Let's expand the state, one schema at a time. If necessary, i.e. if it really helps
-        // performance, we could implement some form of std iterator
-        for (const auto& action:task.get_action_schemas()) {
-            auto applicable = generator.get_applicable_actions(action, state);
-            statistics.inc_generated(applicable.size());
+        const auto applicable = generator.get_applicable_actions(action_schemas, state);
+        statistics.inc_generated(applicable.size());
 
-            for (const LiftedOperatorId& op_id:applicable) {
-                DBState s = generator.generate_successor(op_id, action, state);
+        for (const LiftedOperatorId& op_id:applicable) {
+            const auto &action = action_schemas[op_id.get_index()];
+            DBState s = generator.generate_successor(op_id, action, state);
 
-                int dist = g + action.get_cost();
-                int new_h = heuristic.compute_heuristic(s, task);
-                statistics.inc_evaluations();
-                if (new_h == UNSOLVABLE_STATE) {
-                    statistics.inc_dead_ends();
-                    statistics.inc_pruned_states();
-                    continue;
-                }
+            int dist = g + action.get_cost();
+            int new_h = heuristic.compute_heuristic(s, task);
+            statistics.inc_evaluations();
+            if (new_h == UNSOLVABLE_STATE) {
+                statistics.inc_dead_ends();
+                statistics.inc_pruned_states();
+                continue;
+            }
 
-                auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
-                if (child_node.status == SearchNode::Status::NEW) {
-                    // Inserted for the first time in the map
-                    child_node.open(dist, new_h);
-                    statistics.inc_evaluated_states();
+            auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
+            if (child_node.status == SearchNode::Status::NEW) {
+                // Inserted for the first time in the map
+                child_node.open(dist, new_h);
+                statistics.inc_evaluated_states();
+                queue.do_insertion(child_node.state_id, make_pair(new_h+dist, new_h));
+            }
+            else {
+                if (dist < child_node.g) {
+                    child_node.open(dist, new_h); // Reopening
+                    statistics.inc_reopened();
                     queue.do_insertion(child_node.state_id, make_pair(new_h+dist, new_h));
-                }
-                else {
-                    if (dist < child_node.g) {
-                        child_node.open(dist, new_h); // Reopening
-                        statistics.inc_reopened();
-                        queue.do_insertion(child_node.state_id, make_pair(new_h+dist, new_h));
-                    }
                 }
             }
         }

--- a/src/search/search_engines/breadth_first_width_search.cc
+++ b/src/search/search_engines/breadth_first_width_search.cc
@@ -44,6 +44,7 @@ utils::ExitCode BreadthFirstWidthSearch<PackedStateT>::search(const Task &task,
 {
     cout << "Starting BFWS" << endl;
     clock_t timer_start = clock();
+    const auto action_schemas = task.get_action_schemas();
     StatePackerT packer(task);
 
     Goalcount gc;
@@ -112,55 +113,54 @@ utils::ExitCode BreadthFirstWidthSearch<PackedStateT>::search(const Task &task,
         int unsatisfied_goal_parent = map_state_to_evaluators.at(sid.id()).unsatisfied_goals;
         int unsatisfied_relevant_atoms_parent = map_state_to_evaluators.at(sid.id()).unsatisfied_relevant_atoms;
 
-        for (const auto& action:task.get_action_schemas()) {
-            auto applicable = generator.get_applicable_actions(action, state);
-            statistics.inc_generated(applicable.size());
+        const auto applicable = generator.get_applicable_actions(action_schemas, state);
+        statistics.inc_generated(applicable.size());
 
-            for (const LiftedOperatorId& op_id:applicable) {
-                DBState s = generator.generate_successor(op_id, action, state);
-                auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
-                if (child_node.status != SearchNode::Status::NEW)
-                    continue;
+        for (const LiftedOperatorId& op_id:applicable) {
+            const auto &action = action_schemas[op_id.get_index()];
+            DBState s = generator.generate_successor(op_id, action, state);
+            auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
+            if (child_node.status != SearchNode::Status::NEW)
+                continue;
 
-                int dist = g + action.get_cost();
-                int unsatisfied_goals = gc.compute_heuristic(s, task);
-                int unsatisfied_relevant_atoms = 0;
+            int dist = g + action.get_cost();
+            int unsatisfied_goals = gc.compute_heuristic(s, task);
+            int unsatisfied_relevant_atoms = 0;
 
-                if (method == StandardNovelty::IW) {
-                    unsatisfied_relevant_atoms = 0;
-                    // Important is to make it constant different than 0, otherwise the novelty will
-                    // be 0 because of the goal detection in the evaluator.
-                    unsatisfied_goals = 1;
-                }
-                if (method == StandardNovelty::R_X)
-                    unsatisfied_relevant_atoms = atom_counter.count_unachieved_atoms(s, task);
-
-                if (only_effects_opt and (unsatisfied_goals == unsatisfied_goal_parent) and (unsatisfied_relevant_atoms == unsatisfied_relevant_atoms_parent)) {
-                    novelty_value = novelty_evaluator.compute_novelty_from_operator(task,
-                                                                                    s,
-                                                                                    unsatisfied_goals,
-                                                                                    unsatisfied_relevant_atoms,
-                                                                                    generator.get_added_atoms());
-                }
-                else {
-                    novelty_value = novelty_evaluator.compute_novelty(task,
-                                                                      s,
-                                                                      unsatisfied_goals,
-                                                                      unsatisfied_relevant_atoms);
-
-                }
-
-                statistics.inc_evaluations();
-                statistics.inc_evaluated_states();
-
-                if ((prune_states) and (novelty_value == StandardNovelty::NOVELTY_GREATER_THAN_TWO))
-                    continue;
-
-                child_node.open(dist, novelty_value);
-                if (check_goal(task, generator, timer_start, s, child_node, space)) return utils::ExitCode::SUCCESS;
-                queue.do_insertion(child_node.state_id, {novelty_value, unsatisfied_goals, dist});
-                map_state_to_evaluators.insert({child_node.state_id.id(), NodeNovelty(unsatisfied_goals, unsatisfied_relevant_atoms)});
+            if (method == StandardNovelty::IW) {
+                unsatisfied_relevant_atoms = 0;
+                // Important is to make it constant different than 0, otherwise the novelty will
+                // be 0 because of the goal detection in the evaluator.
+                unsatisfied_goals = 1;
             }
+            if (method == StandardNovelty::R_X)
+                unsatisfied_relevant_atoms = atom_counter.count_unachieved_atoms(s, task);
+
+            if (only_effects_opt and (unsatisfied_goals == unsatisfied_goal_parent) and (unsatisfied_relevant_atoms == unsatisfied_relevant_atoms_parent)) {
+                novelty_value = novelty_evaluator.compute_novelty_from_operator(task,
+                                                                                s,
+                                                                                unsatisfied_goals,
+                                                                                unsatisfied_relevant_atoms,
+                                                                                generator.get_added_atoms());
+            }
+            else {
+                novelty_value = novelty_evaluator.compute_novelty(task,
+                                                                  s,
+                                                                  unsatisfied_goals,
+                                                                  unsatisfied_relevant_atoms);
+
+            }
+
+            statistics.inc_evaluations();
+            statistics.inc_evaluated_states();
+
+            if ((prune_states) and (novelty_value == StandardNovelty::NOVELTY_GREATER_THAN_TWO))
+                continue;
+
+            child_node.open(dist, novelty_value);
+            if (check_goal(task, generator, timer_start, s, child_node, space)) return utils::ExitCode::SUCCESS;
+            queue.do_insertion(child_node.state_id, {novelty_value, unsatisfied_goals, dist});
+            map_state_to_evaluators.insert({child_node.state_id.id(), NodeNovelty(unsatisfied_goals, unsatisfied_relevant_atoms)});
         }
     }
 

--- a/src/search/search_engines/dual_queue_bfws.cc
+++ b/src/search/search_engines/dual_queue_bfws.cc
@@ -20,6 +20,7 @@ utils::ExitCode DualQueueBFWS<PackedStateT>::search(const Task &task,
                                                     Heuristic &heuristic) {
     cout << "Starting Dual-Queue BFWS" << endl;
     clock_t timer_start = clock();
+    const auto action_schemas = task.get_action_schemas();
     StatePackerT packer(task);
 
     Goalcount gc;
@@ -31,7 +32,7 @@ utils::ExitCode DualQueueBFWS<PackedStateT>::search(const Task &task,
 
     atom_counter = initialize_counter_with_useful_atoms(task, delete_free_h);
     number_relevant_atoms = atom_counter.get_total_number_of_atoms();
-    
+
     // We use a GreedyOpenList (ordered by the novelty value) for now. This is done to make the
     // search algorithm complete.
     TieBreakingOpenList regular_open_list;
@@ -87,51 +88,50 @@ utils::ExitCode DualQueueBFWS<PackedStateT>::search(const Task &task,
             boost_priority_queue();
         }
 
-        for (const auto& action:task.get_action_schemas()) {
-            auto applicable = generator.get_applicable_actions(action, state);
-            statistics.inc_generated(applicable.size());
+        const auto applicable = generator.get_applicable_actions(action_schemas, state);
+        statistics.inc_generated(applicable.size());
 
-            for (const LiftedOperatorId& op_id:applicable) {
-                DBState s = generator.generate_successor(op_id, action, state);
-                auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
-                if (child_node.status != SearchNode::Status::NEW)
-                    continue;
-                bool is_preferred = is_useful_operator(task, s, delete_free_h.get_useful_atoms());
-                int dist = g + action.get_cost();
-                int unsatisfied_goals = gc.compute_heuristic(s, task);
-                int unsatisfied_relevant_atoms = 0;
+        for (const LiftedOperatorId& op_id:applicable) {
+            const auto &action = action_schemas[op_id.get_index()];
+            DBState s = generator.generate_successor(op_id, action, state);
+            auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
+            if (child_node.status != SearchNode::Status::NEW)
+                continue;
+            bool is_preferred = is_useful_operator(task, s, delete_free_h.get_useful_atoms());
+            int dist = g + action.get_cost();
+            int unsatisfied_goals = gc.compute_heuristic(s, task);
+            int unsatisfied_relevant_atoms = 0;
 
-                unsatisfied_relevant_atoms = atom_counter.count_unachieved_atoms(s, task);
+            unsatisfied_relevant_atoms = atom_counter.count_unachieved_atoms(s, task);
 
-                if (only_effects_opt and (unsatisfied_goals == unsatisfied_goal_parent) and (unsatisfied_relevant_atoms == unsatisfied_relevant_atoms_parent)) {
-                    novelty_value = novelty_evaluator.compute_novelty_from_operator(task,
-                                                                                    s,
-                                                                                    unsatisfied_goals,
-                                                                                    unsatisfied_relevant_atoms,
-                                                                                    generator.get_added_atoms());
-                }
-                else {
-                    novelty_value = novelty_evaluator.compute_novelty(task,
-                                                                      s,
-                                                                      unsatisfied_goals,
-                                                                      unsatisfied_relevant_atoms);
-
-                }
-
-                statistics.inc_evaluations();
-                statistics.inc_evaluated_states();
-
-                child_node.open(dist, novelty_value);
-                if (check_goal(task, generator, timer_start, s, child_node, space)) return utils::ExitCode::SUCCESS;
-                if (is_preferred) {
-                    preferred_open_list.do_insertion(child_node.state_id,
-                                                     {novelty_value, unsatisfied_goals, dist});
-                }
-                // Using a boosted dual queue, it is needed to insert every node in the regular
-                // open list for completeness.
-                regular_open_list.do_insertion(child_node.state_id,{novelty_value, unsatisfied_goals, dist});
-                map_state_to_evaluators.insert({child_node.state_id.id(), NodeNovelty(unsatisfied_goals, unsatisfied_relevant_atoms)});
+            if (only_effects_opt and (unsatisfied_goals == unsatisfied_goal_parent) and (unsatisfied_relevant_atoms == unsatisfied_relevant_atoms_parent)) {
+                novelty_value = novelty_evaluator.compute_novelty_from_operator(task,
+                                                                                s,
+                                                                                unsatisfied_goals,
+                                                                                unsatisfied_relevant_atoms,
+                                                                                generator.get_added_atoms());
             }
+            else {
+                novelty_value = novelty_evaluator.compute_novelty(task,
+                                                                  s,
+                                                                  unsatisfied_goals,
+                                                                  unsatisfied_relevant_atoms);
+
+            }
+
+            statistics.inc_evaluations();
+            statistics.inc_evaluated_states();
+
+            child_node.open(dist, novelty_value);
+            if (check_goal(task, generator, timer_start, s, child_node, space)) return utils::ExitCode::SUCCESS;
+            if (is_preferred) {
+                preferred_open_list.do_insertion(child_node.state_id,
+                                                    {novelty_value, unsatisfied_goals, dist});
+            }
+            // Using a boosted dual queue, it is needed to insert every node in the regular
+            // open list for completeness.
+            regular_open_list.do_insertion(child_node.state_id,{novelty_value, unsatisfied_goals, dist});
+            map_state_to_evaluators.insert({child_node.state_id.id(), NodeNovelty(unsatisfied_goals, unsatisfied_relevant_atoms)});
         }
     }
 

--- a/src/search/search_engines/greedy_best_first_search.cc
+++ b/src/search/search_engines/greedy_best_first_search.cc
@@ -25,6 +25,7 @@ utils::ExitCode GreedyBestFirstSearch<PackedStateT>::search(const Task &task,
 {
     cout << "Starting greedy best first search" << endl;
     clock_t timer_start = clock();
+    const auto action_schemas = task.get_action_schemas();
     StatePackerT packer(task);
 
     GreedyOpenList queue;
@@ -71,40 +72,37 @@ utils::ExitCode GreedyBestFirstSearch<PackedStateT>::search(const Task &task,
         DBState state = packer.unpack(space.get_state(sid));
         if (check_goal(task, generator, timer_start, state, node, space)) return utils::ExitCode::SUCCESS;
 
-        // Let's expand the state, one schema at a time. If necessary, i.e. if it really helps
-        // performance, we could implement some form of std iterator
-        for (const auto& action:task.get_action_schemas()) {
-            auto applicable = generator.get_applicable_actions(action, state);
-            statistics.inc_generated(applicable.size());
+        const auto applicable = generator.get_applicable_actions(action_schemas, state);
+        statistics.inc_generated(applicable.size());
 
-            for (const LiftedOperatorId& op_id:applicable) {
-                DBState s = generator.generate_successor(op_id, action, state);
-                auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
-                int dist = g + action.get_cost();
-                int new_h = heuristic.compute_heuristic(s, task);
-                statistics.inc_evaluations();
-                if (new_h == UNSOLVABLE_STATE) {
-                    if (child_node.status == SearchNode::Status::NEW) {
-                        // Only increase statistics for new dead-ends
-                        child_node.open(dist, new_h);
-                        statistics.inc_dead_ends();
-                        statistics.inc_pruned_states();
-                    }
-                    continue;
-                }
-
+        for (const LiftedOperatorId& op_id:applicable) {
+            const auto &action = action_schemas[op_id.get_index()];
+            DBState s = generator.generate_successor(op_id, action, state);
+            auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
+            int dist = g + action.get_cost();
+            int new_h = heuristic.compute_heuristic(s, task);
+            statistics.inc_evaluations();
+            if (new_h == UNSOLVABLE_STATE) {
                 if (child_node.status == SearchNode::Status::NEW) {
-                    // Inserted for the first time in the map
+                    // Only increase statistics for new dead-ends
                     child_node.open(dist, new_h);
-                    statistics.inc_evaluated_states();
-                    queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
+                    statistics.inc_dead_ends();
+                    statistics.inc_pruned_states();
                 }
-                else {
-                    if (dist < child_node.g) {
-                        child_node.open(dist, new_h); // Reopening
-                        statistics.inc_reopened();
-                        queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
-                    }
+                continue;
+            }
+
+            if (child_node.status == SearchNode::Status::NEW) {
+                // Inserted for the first time in the map
+                child_node.open(dist, new_h);
+                statistics.inc_evaluated_states();
+                queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
+            }
+            else {
+                if (dist < child_node.g) {
+                    child_node.open(dist, new_h); // Reopening
+                    statistics.inc_reopened();
+                    queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
                 }
             }
         }

--- a/src/search/structures.h
+++ b/src/search/structures.h
@@ -30,11 +30,31 @@ struct Parameter {
     int index;
     int type;
 
-    int get_index() {
+    int get_index() const {
         return index;
+    }
+
+    bool operator<(const Parameter& other) const {
+        return index < other.index;
+    }
+
+    bool operator==(const Parameter& other) const {
+        return index == other.index;
+    }
+
+    bool operator!=(const Parameter& other) const {
+        return index != other.index;
     }
 };
 
+namespace std {
+template <>
+struct hash<Parameter> {
+    size_t operator()(const Parameter &parameter) const {
+        return hash<int>()(parameter.get_index());
+    }
+};
+}  // namespace std
 
 /**
  * @brief Implements an argument composing an atom. It can be a free

--- a/src/search/successor_generators/clique_bron_kerbosch.cc
+++ b/src/search/successor_generators/clique_bron_kerbosch.cc
@@ -1,0 +1,300 @@
+#include "clique_bron_kerbosch.h"
+#include "clique_help_functions.h"
+
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+using namespace std;
+
+inline void insert_sorted(vector<uint32_t> &vec, uint32_t item) {
+    vec.insert(upper_bound(vec.begin(), vec.end(), item), item);
+}
+
+inline void erase_index(vector<uint32_t> &vec, size_t index) {
+    vec.erase(vec.begin() + index);
+}
+
+inline void erase_sorted(vector<uint32_t> &vec, uint32_t item) {
+    auto lb = lower_bound(begin(vec), end(vec), item);
+    if ((lb != end(vec)) && (*lb == item)) {
+        vec.erase(lb, lb + 1);
+    }
+}
+
+template <typename P>
+void bron_kerbosch_with_pivoting(const vector<uint32_t> adjacency_list[],
+                                 const size_t max_clique_size,
+                                 const vector<uint32_t> &r_sorted,
+                                 const vector<uint32_t> &p_sorted,
+                                 const vector<uint32_t> &x_sorted,
+                                 vector<vector<uint32_t>> &out_cliques) {
+    vector<tuple<vector<uint32_t>, vector<uint32_t>, vector<uint32_t>>> stack;
+    stack.push_back(make_tuple(r_sorted, p_sorted, x_sorted));
+
+    while (!stack.empty()) {
+        auto &frame = stack.back();
+        auto r = get<0>(frame);
+        auto p = get<1>(frame);
+        auto x = get<2>(frame);
+        stack.pop_back();
+
+        if ((r.size() + p.size()) < max_clique_size) {
+            // This branch cannot lead to a maximum clique: prune it.
+        }
+        else if ((p.size() == 0) && (x.size() == 0)) {
+            if (r.size() == max_clique_size) {
+                // If P and X are both empty then report R as a maximum clique
+                out_cliques.push_back(r);
+            }
+        }
+        else if (p.size() > 0) {
+            const auto u = P::get_pivot(adjacency_list, p, x);
+            const auto &n_u = adjacency_list[u];
+
+            size_t p_i = 0;
+            size_t n_u_i = 0;
+
+            while (p_i < p.size()) {
+                const auto v = p[p_i];
+                const auto w = (n_u_i < n_u.size()) ? n_u[n_u_i] : numeric_limits<uint32_t>::max();
+
+                if (v < w) {
+                    const auto &n_v = adjacency_list[v];
+
+                    vector<uint32_t> union_r = r;
+                    insert_sorted(union_r, v);
+
+                    vector<uint32_t> intersect_p;
+                    set_intersection(n_v.begin(),
+                                     n_v.end(),
+                                     p.begin(),
+                                     p.end(),
+                                     back_inserter(intersect_p));
+
+                    vector<uint32_t> intersect_x;
+                    set_intersection(n_v.begin(),
+                                     n_v.end(),
+                                     x.begin(),
+                                     x.end(),
+                                     back_inserter(intersect_x));
+
+                    stack.push_back(make_tuple(std::move(union_r),
+                                               std::move(intersect_p),
+                                               std::move(intersect_x)));
+
+                    erase_index(p, p_i);  // This also moves the p_i forward
+
+                    insert_sorted(x, v);
+                }
+                else if (v > w) {
+                    ++n_u_i;
+                }
+                else {
+                    ++p_i;
+                    ++n_u_i;
+                }
+            }
+        }
+    }
+}
+
+template <typename P>
+void bron_kerbosch_with_vertex_ordering(const vector<uint32_t> adjacency_list[],
+                                        const vector<uint32_t> &vertices,
+                                        size_t max_clique_size,
+                                        vector<vector<uint32_t>> &out_cliques) {
+    vector<uint32_t> degeneracy_ordering(vertices);
+    sort(degeneracy_ordering.begin(),
+         degeneracy_ordering.end(),
+         [&adjacency_list](uint32_t lhs, uint32_t rhs) {
+             return adjacency_list[lhs].size() < adjacency_list[rhs].size();
+         });
+
+    vector<uint32_t> p(vertices);
+    sort(p.begin(), p.end());
+    vector<uint32_t> x;
+
+    vector<uint32_t> singleton_v;
+    vector<uint32_t> intersect_p;
+    vector<uint32_t> intersect_x;
+
+    for (auto vertex_id : degeneracy_ordering) {
+        const auto &vertex_neighbors = adjacency_list[vertex_id];
+
+        singleton_v.push_back(vertex_id);
+
+        intersect_p.clear();
+        set_intersection(vertex_neighbors.begin(),
+                         vertex_neighbors.end(),
+                         p.begin(),
+                         p.end(),
+                         back_inserter(intersect_p));
+
+        intersect_x.clear();
+        set_intersection(vertex_neighbors.begin(),
+                         vertex_neighbors.end(),
+                         x.begin(),
+                         x.end(),
+                         back_inserter(intersect_x));
+
+        bron_kerbosch_with_pivoting<P>(adjacency_list,
+                                       max_clique_size,
+                                       singleton_v,
+                                       intersect_p,
+                                       intersect_x,
+                                       out_cliques);
+
+        singleton_v.pop_back();
+
+        erase_sorted(p, vertex_id);
+        insert_sorted(x, vertex_id);
+    }
+}
+
+struct FirstPivot {
+    static uint32_t get_pivot(const vector<uint32_t> adjacency_list[],
+                              const vector<uint32_t> &p,
+                              const vector<uint32_t> &x) {
+        return (x.size() > 0) ? x.front() : p.front();
+    }
+};
+
+
+struct MaxNeighborhoodPivot {
+    inline static uint32_t get_pivot(const vector<uint32_t> adjacency_list[],
+                                     const vector<uint32_t> &p,
+                                     const vector<uint32_t> &x) {
+        // Find the vertex v that maximizes |n(v)|.
+
+        bool initialized = false;
+        uint32_t best_vertex = p[0];
+        size_t best_score;
+
+        for (const auto v : p) {
+            const auto score = adjacency_list[v].size();
+
+            if (!initialized || (score >= best_score)) {
+                initialized = true;
+                best_vertex = v;
+                best_score = score;
+            }
+        }
+
+        for (const auto v : x) {
+            const auto score = adjacency_list[v].size();
+
+            if (!initialized || (score >= best_score)) {
+                initialized = true;
+                best_vertex = v;
+                best_score = score;
+            }
+        }
+
+        return best_vertex;
+    }
+};
+
+struct MinDifferencePivot {
+    inline static int32_t difference_size(const vector<uint32_t> &p, const vector<uint32_t> &n) {
+        // The score is |p - n|
+
+        if ((p.back() < n.front()) || (p.front() > n.back())) {
+            return p.size();
+        }
+        else {
+            int32_t score = 0;
+
+            size_t p_size = p.size();
+            size_t n_size = n.size();
+
+            size_t p_i = 0;
+            size_t n_i = 0;
+
+            while (p_i < p_size) {
+                const auto u = p[p_i];
+
+                if (n_i < n_size) {
+                    const auto v = n[n_i];
+
+                    if (u < v) {
+                        ++score;
+                        ++p_i;
+                    }
+                    else if (u > v) {
+                        ++n_i;
+                    }
+                    else {
+                        ++p_i;
+                        ++n_i;
+                    }
+                }
+                else {
+                    score += p_size - p_i;
+                    break;
+                }
+            }
+
+            return score;
+        }
+    }
+
+    inline static uint32_t get_pivot(const vector<uint32_t> adjacency_list[],
+                                     const vector<uint32_t> &p,
+                                     const vector<uint32_t> &x) {
+        // Find the vertex v that minimizes |p - n(v)|.
+
+        uint32_t best_vertex = numeric_limits<uint32_t>::max();
+        int32_t best_score = numeric_limits<int32_t>::max();
+
+        for (const auto v : p) {
+            const auto score = difference_size(p, adjacency_list[v]);
+
+            if (score <= best_score) {
+                best_vertex = v;
+                best_score = score;
+            }
+        }
+
+        for (const auto v : x) {
+            const auto score = difference_size(p, adjacency_list[v]);
+
+            if (score <= best_score) {
+                best_vertex = v;
+                best_score = score;
+            }
+        }
+
+        return best_vertex;
+    }
+};
+
+void bron_kerbosch_first_pivot(const vector<uint32_t> adjacency_list[],
+                               const vector<uint32_t> &vertices,
+                               size_t max_clique_size,
+                               vector<vector<uint32_t>> &out_cliques) {
+    bron_kerbosch_with_vertex_ordering<FirstPivot>(adjacency_list,
+                                                   vertices,
+                                                   max_clique_size,
+                                                   out_cliques);
+}
+
+void bron_kerbosch_max_neighborhood_pivot(const vector<uint32_t> adjacency_list[],
+                                          const vector<uint32_t> &vertices,
+                                          size_t max_clique_size,
+                                          vector<vector<uint32_t>> &out_cliques) {
+    bron_kerbosch_with_vertex_ordering<MaxNeighborhoodPivot>(adjacency_list,
+                                                             vertices,
+                                                             max_clique_size,
+                                                             out_cliques);
+}
+
+void bron_kerbosch_min_difference_pivot(const vector<uint32_t> adjacency_list[],
+                                        const vector<uint32_t> &vertices,
+                                        size_t max_clique_size,
+                                        vector<vector<uint32_t>> &out_cliques) {
+    bron_kerbosch_with_vertex_ordering<MinDifferencePivot>(adjacency_list,
+                                                           vertices,
+                                                           max_clique_size,
+                                                           out_cliques);
+}

--- a/src/search/successor_generators/clique_bron_kerbosch.h
+++ b/src/search/successor_generators/clique_bron_kerbosch.h
@@ -1,0 +1,17 @@
+#include <cstdint>
+#include <vector>
+
+void bron_kerbosch_first_pivot(const std::vector<uint32_t> adjacency_list[],
+                               const std::vector<uint32_t> &vertices,
+                               std::size_t max_clique_size,
+                               std::vector<std::vector<uint32_t>> &out_cliques);
+
+void bron_kerbosch_max_neighborhood_pivot(const std::vector<uint32_t> adjacency_list[],
+                                          const std::vector<uint32_t> &vertices,
+                                          std::size_t max_clique_size,
+                                          std::vector<std::vector<uint32_t>> &out_cliques);
+
+void bron_kerbosch_min_difference_pivot(const std::vector<uint32_t> adjacency_list[],
+                                        const std::vector<uint32_t> &vertices,
+                                        std::size_t max_clique_size,
+                                        std::vector<std::vector<uint32_t>> &out_cliques);

--- a/src/search/successor_generators/clique_help_functions.cc
+++ b/src/search/successor_generators/clique_help_functions.cc
@@ -1,0 +1,45 @@
+#include "clique_help_functions.h"
+
+using namespace std;
+
+bool literal_holds(const LiftedOperatorId &op,
+                   const vector<Atom> &literals,
+                   const DBState &state,
+                   const size_t min_test_arity) {
+    const auto &operator_instantiation = op.get_instantiation();
+
+    for (const auto &literal : literals) {
+        if (literal.get_arguments().size() >= min_test_arity) {
+            GroundAtom relation_instance;
+            for (const auto argument : literal.get_arguments()) {
+                if (argument.is_constant()) {
+                    relation_instance.push_back(argument.get_index());
+                }
+                else {
+                    relation_instance.push_back(operator_instantiation.at(argument.get_index()));
+                }
+            }
+
+            const auto &relation_tuples =
+                state.get_tuples_of_relation(literal.get_predicate_symbol_idx());
+            const auto relation_exists =
+                relation_tuples.find(relation_instance) != relation_tuples.end();
+
+            if (relation_exists == literal.is_negated()) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool literal_holds(const LiftedOperatorId &op,
+                   const vector<Atom> &dynamic_literals,
+                   const vector<Atom> &static_literals,
+                   const DBState &dynamic_state,
+                   const DBState &static_state,
+                   const size_t min_test_arity) {
+    return literal_holds(op, static_literals, static_state, min_test_arity) &&
+           literal_holds(op, dynamic_literals, dynamic_state, min_test_arity);
+}

--- a/src/search/successor_generators/clique_help_functions.h
+++ b/src/search/successor_generators/clique_help_functions.h
@@ -1,0 +1,42 @@
+#include "../action.h"
+#include "../atom.h"
+#include "../states/state.h"
+
+#include <vector>
+
+inline size_t get_rank(int first_position,
+                       int first_object,
+                       int second_position,
+                       int second_object,
+                       int arity,
+                       int num_objects) {
+    const auto first = 1;
+    const auto second = first * (arity + 1);
+    const auto third = second * (arity + 1);
+    const auto fourth = third * (num_objects + 1);
+    const auto rank = (first * (first_position + 1)) + (second * (second_position + 1)) +
+                      (third * (first_object + 1)) + (fourth * (second_object + 1));
+    return (size_t)rank;
+}
+
+inline size_t total_ranks(int arity, int num_objects) {
+    const auto first = 1;
+    const auto second = first * (arity + 1);
+    const auto third = second * (arity + 1);
+    const auto fourth = third * (num_objects + 1);
+    const auto max =
+        (first * arity) + (second * arity) + (third * num_objects) + (fourth * num_objects);
+    return (size_t)(max + 1);
+}
+
+bool literal_holds(const LiftedOperatorId &op,
+                   const std::vector<Atom> &literals,
+                   const DBState &state,
+                   const size_t min_test_arity);
+
+bool literal_holds(const LiftedOperatorId &op,
+                   const std::vector<Atom> &dynamic_literals,
+                   const std::vector<Atom> &static_literals,
+                   const DBState &dynamic_state,
+                   const DBState &static_state,
+                   const size_t min_test_arity);

--- a/src/search/successor_generators/clique_successor_generator.cc
+++ b/src/search/successor_generators/clique_successor_generator.cc
@@ -1,0 +1,580 @@
+#include "../algorithms/kpkc.h"
+#include "clique_bron_kerbosch.h"
+#include "clique_help_functions.h"
+#include "clique_successor_generator.h"
+
+#include <cassert>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <unordered_set>
+#include <vector>
+
+using namespace std;
+
+bool CliqueSuccessorGenerator::consistent_literals(const vector<Atom> &literals,
+                                                   const Assignment &first_assignment,
+                                                   const Assignment &second_assignment) {
+    const auto num_objects = task.objects.size();
+
+    for (const auto &literal : literals) {
+        int first_position = -1;
+        int second_position = -1;
+        int first_object = -1;
+        int second_object = -1;
+        bool empty_assignment = true;
+        const auto &parameters = literal.get_arguments();
+        const auto predicate_arity = parameters.size();
+
+        // For literals of arity > 2 that contains constants,
+        // the constants are ignored which means that we might
+        // enumerate inapplicable ground actions.
+        // (This is not a problem since we test such predicates.)
+
+        for (size_t index = 0; index < predicate_arity; ++index) {
+            const auto &parameter = parameters[index];
+            const auto is_constant = parameter.is_constant();
+            const auto parameter_index = parameter.get_index();
+
+            if (is_constant) {
+                if (predicate_arity <= 2) {
+                    if (first_position < 0) {
+                        first_position = index;
+                        first_object = parameter_index;
+                    }
+                    else {
+                        second_position = index;
+                        second_object = parameter_index;
+                    }
+
+                    empty_assignment = false;
+                }
+            }
+            else {
+                if (first_assignment.parameter_index == parameter_index) {
+                    if (first_position < 0) {
+                        first_position = index;
+                        first_object = first_assignment.object_index;
+                    }
+                    else {
+                        second_position = index;
+                        second_object = first_assignment.object_index;
+                        break;
+                    }
+
+                    empty_assignment = false;
+                }
+                else if (second_assignment.parameter_index == parameter_index) {
+                    if (first_position < 0) {
+                        first_position = index;
+                        first_object = second_assignment.object_index;
+                    }
+                    else {
+                        second_position = index;
+                        second_object = second_assignment.object_index;
+                        break;
+                    }
+
+                    empty_assignment = false;
+                }
+            }
+        }
+
+        if (!empty_assignment) {
+            // The size of assignment_sets should be number of predicates,
+            // and each assignment_set should have size determined by total_ranks(.).
+            // That is, the indexing should be safe.
+
+            const auto predicate_symbol = literal.get_predicate_symbol_idx();
+            const auto &assignment_set = assignment_sets[predicate_symbol];
+            const auto assignment_rank = get_rank(first_position,
+                                                  first_object,
+                                                  second_position,
+                                                  second_object,
+                                                  predicate_arity,
+                                                  num_objects);
+            const auto consistent_with_state = assignment_set[assignment_rank];
+
+            // A positive literal is inconsistent if there does not exist a (partially ground) atom
+            // in the state. A negative literal is inconsistent if the assignment matches a fully
+            // ground atom in the state.
+
+            if (!literal.is_negated() && !consistent_with_state) {
+                return false;
+            }
+            else if (literal.is_negated() && consistent_with_state &&
+                     ((predicate_arity == 1) ||
+                      ((predicate_arity == 2) && (second_position >= 0)))) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+bool CliqueSuccessorGenerator::consistent_literals_with_constants(const vector<Atom> &literals) {
+    const auto empty_assignment = Assignment(-1, -1);
+    return consistent_literals(literals, empty_assignment, empty_assignment);
+}
+
+
+bool CliqueSuccessorGenerator::test_nullary_preconditions(const ActionSchema &action,
+                                                          const DBState &state) {
+    // If a nullary atom does not hold then all instantiations are inapplicable.
+    const auto &nullary_atoms = state.get_nullary_atoms();
+    const auto &positive_nullary = action.get_positive_nullary_precond();
+    for (uint32_t index = 0; index < positive_nullary.size(); ++index) {
+        if (positive_nullary[index] && !nullary_atoms[index]) {
+            return false;
+        }
+    }
+
+    const auto &negative_nullary = action.get_negative_nullary_precond();
+    for (uint32_t index = 0; index < negative_nullary.size(); ++index) {
+        if (negative_nullary[index] && nullary_atoms[index]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * @brief Builds a datastructure to efficiently test if an assignment is compatible with an atom in
+ * the given set.
+ *
+ * @return A set for each predicate that contains possible compatible assignments.
+ */
+void CliqueSuccessorGenerator::build_assignment_sets(const DBState &atoms) {
+    const auto num_objects = task.objects.size();
+    const auto &relations = atoms.get_relations();
+
+    if (assignment_sets.size() < relations.size()) {
+        assignment_sets.resize(relations.size());
+    }
+
+    for (auto &assignment_set : assignment_sets) {
+        assignment_set.clear();
+    }
+
+    for (const auto &relation : relations) {
+        const auto predicate_arity = task.predicates[relation.predicate_symbol].getArity();
+        auto &assignment_set = assignment_sets[relation.predicate_symbol];
+        assignment_set.resize(total_ranks(predicate_arity, num_objects));
+
+        for (const auto &atom : relation.tuples) {
+            for (size_t first_position = 0; first_position < atom.size(); ++first_position) {
+                const auto first_object = atom[first_position];
+
+                assignment_set[get_rank(
+                    first_position, first_object, -1, -1, predicate_arity, num_objects)] = true;
+
+                for (size_t second_position = first_position + 1; second_position < atom.size();
+                     ++second_position) {
+                    const auto second_object = atom[second_position];
+                    assignment_set[get_rank(
+                        second_position, second_object, -1, -1, predicate_arity, num_objects)] =
+                        true;
+                    assignment_set[get_rank(first_position,
+                                            first_object,
+                                            second_position,
+                                            second_object,
+                                            predicate_arity,
+                                            num_objects)] = true;
+                }
+            }
+        }
+    }
+}
+
+CliqueSuccessorGenerator::CliqueSuccessorGenerator(const Task &task, const CliquePivot &pivot)
+    : task(task), pivot(pivot) {
+    // Types are static information, precompute the set of object that
+    // can be assigned to each parameter based on type information.
+
+    // Inequality is translated to static binary relations, we do not
+    // need to take special care of these.
+
+    build_assignment_sets(task.get_static_info());
+
+    for (const auto &action : task.get_action_schemas()) {
+        unordered_map<Parameter, set<Object>> parameter_assignments;
+        for (const auto &parameter : action.get_parameters()) {
+            set<Object> compatible_objects;
+
+            for (const auto &object : task.objects) {
+                for (const auto &type : object.get_types()) {
+                    if (type == parameter.type) {
+                        compatible_objects.insert(object);
+                    }
+                }
+            }
+
+            parameter_assignments.insert(make_pair(parameter, compatible_objects));
+        }
+
+        action_objects_by_parameter_type.insert(make_pair(action, parameter_assignments));
+
+        int last_cumulative_partition_size = 0;
+        vector<vector<size_t>> partitions;
+        vector<Assignment> to_vertex_assignment;
+
+        for (const auto &parameter : action.get_parameters()) {
+            vector<size_t> partition;
+            const auto compatible_objects = parameter_assignments.at(parameter);
+            const int cumulative_partition_size =
+                last_cumulative_partition_size + (int)compatible_objects.size();
+            last_cumulative_partition_size = cumulative_partition_size;
+
+            for (const auto &object : compatible_objects) {
+                partition.push_back(to_vertex_assignment.size());
+                const Assignment vertex_assignment(parameter.get_index(), object.get_index());
+                to_vertex_assignment.push_back(vertex_assignment);
+            }
+
+            partitions.push_back(std::move(partition));
+        }
+
+        set<string> static_predicate_names;
+        set<string> dynamic_predicate_names;
+
+        for (const auto &predicate : task.predicates) {
+            if (predicate.get_name().rfind("type@", 0) == string::npos) {
+                if (predicate.isStaticPredicate()) {
+                    static_predicate_names.insert(predicate.get_name());
+                }
+                else {
+                    dynamic_predicate_names.insert(predicate.get_name());
+                }
+            }
+        }
+
+        const auto &literals = action.get_precondition();
+        vector<Atom> static_precondition;
+        vector<Atom> dynamic_precondition;
+        vector<AssignmentPair> statically_consistent_assignments;
+
+        for (const auto &literal : literals) {
+            if (static_predicate_names.find(literal.get_name()) != static_predicate_names.end()) {
+                static_precondition.push_back(literal);
+            }
+            else if (dynamic_predicate_names.find(literal.get_name()) !=
+                     dynamic_predicate_names.end()) {
+                dynamic_precondition.push_back(literal);
+            }
+        }
+
+        for (size_t first_id = 0; first_id < to_vertex_assignment.size(); ++first_id) {
+            for (size_t second_id = (first_id + 1); second_id < to_vertex_assignment.size();
+                 ++second_id) {
+                const auto &first_assignment = to_vertex_assignment.at(first_id);
+                const auto &second_assignment = to_vertex_assignment.at(second_id);
+
+                if (first_assignment.parameter_index != second_assignment.parameter_index) {
+                    if (consistent_literals(
+                            static_precondition, first_assignment, second_assignment)) {
+                        statically_consistent_assignments.push_back(AssignmentPair(
+                            first_id, first_assignment, second_id, second_assignment));
+                    }
+                }
+            }
+        }
+
+        action_precondition.insert(
+            make_pair(action, Precondition(static_precondition, dynamic_precondition)));
+        action_statically_consistent_assignments.insert(
+            make_pair(action, statically_consistent_assignments));
+        action_to_vertex_assignment.insert(make_pair(action, to_vertex_assignment));
+        action_partitions.insert(make_pair(action, partitions));
+    }
+}
+
+vector<LiftedOperatorId> CliqueSuccessorGenerator::applicable_actions_nullary_case(const ActionSchema &action,
+                                                                                   const DBState &state) {
+    vector<LiftedOperatorId> applicable_actions;
+
+    const auto &preconds = action_precondition.find(action)->second;
+    const auto &static_preconds = preconds.static_preconds;
+    const auto &dynamic_preconds = preconds.dynamic_preconds;
+    const auto &static_info = task.get_static_info();
+    const LiftedOperatorId op(action.get_index(), GroundAtom());
+
+    if (literal_holds(op, dynamic_preconds, static_preconds, state, static_info, 1)) {
+        applicable_actions.push_back(op);
+    }
+
+    return applicable_actions;
+}
+
+vector<LiftedOperatorId> CliqueSuccessorGenerator::applicable_actions_unary_case(const ActionSchema &action,
+                                                                                 const DBState &state) {
+    vector<LiftedOperatorId> applicable_actions;
+
+    const auto &preconds = action_precondition.find(action)->second;
+    const auto &static_preconds = preconds.static_preconds;
+    const auto &dynamic_preconds = preconds.dynamic_preconds;
+    const auto &static_info = task.get_static_info();
+    const auto &objects_by_parameter_type = action_objects_by_parameter_type.find(action)->second;
+    const auto &action_parameters = action.get_parameters();
+    const auto &parameter = action_parameters.at(0);
+    const auto &objects_with_correct_type = objects_by_parameter_type.at(parameter);
+
+    for (const auto &object : objects_with_correct_type) {
+        const LiftedOperatorId op(action.get_index(), {object.get_index()});
+
+        if (literal_holds(op, dynamic_preconds, static_preconds, state, static_info, 1)) {
+            applicable_actions.push_back(op);
+        }
+    }
+
+    return applicable_actions;
+}
+
+vector<uint32_t> CliqueSuccessorGenerator::create_adjacency_list(const Precondition &preconds,
+                                                                 const std::vector<AssignmentPair> &statically_consistent_assignments,
+                                                                 std::size_t num_parameters,
+                                                                 vector<uint32_t> *adjacency_list,
+                                                                 std::size_t num_vertices) {
+    for (uint32_t vertex_id = 0; vertex_id < num_vertices; ++vertex_id) {
+        adjacency_list[vertex_id] = vector<uint32_t>();
+    }
+
+    for (const auto &pair : statically_consistent_assignments) {
+        if (consistent_literals(
+                preconds.dynamic_preconds, pair.first_assignment, pair.second_assignment)) {
+            auto &first_neighbors = adjacency_list[pair.first_position];
+            auto &second_neighbors = adjacency_list[pair.second_position];
+            first_neighbors.push_back(pair.second_position);
+            second_neighbors.push_back(pair.first_position);
+        }
+    }
+
+    // Make the graph more sparse by removing edges between vertices
+    // that has a degree less than num_parameters -1. We can safely
+    // do so since they cannot be part of any maximum clique, i.e.,
+    // complete assignment of the parameters.
+
+    bool removed_edges = true;
+    while (removed_edges) {
+        removed_edges = false;
+
+        for (uint32_t id = 0; id < num_vertices; ++id) {
+            auto &neighbors = adjacency_list[id];
+            const auto num_neighbors = neighbors.size();
+
+            if ((num_neighbors > 0) && (num_neighbors < (num_parameters - 1))) {
+                for (const auto neighbor_id : neighbors) {
+                    auto &neighbors = adjacency_list[neighbor_id];
+                    neighbors.erase(find(neighbors.begin(), neighbors.end(), id));
+                }
+
+                neighbors.clear();
+                removed_edges = true;
+            }
+        }
+    }
+
+    vector<uint32_t> vertex_ids;
+    for (uint32_t id = 0; id < num_vertices; ++id) {
+        auto &vertices = adjacency_list[id];
+        if (vertices.size() > 0) {
+            vertex_ids.push_back(id);
+            sort(vertices.begin(), vertices.end());
+        }
+    }
+
+    return vertex_ids;
+}
+
+void CliqueSuccessorGenerator::create_adjacency_matrix(const Precondition &preconds,
+                                                       const std::vector<AssignmentPair> &statically_consistent_assignments,
+                                                       std::size_t num_parameters,
+                                                       std::size_t num_vertices,
+                                                       std::vector<boost::dynamic_bitset<>> &adjacency_matrix) {
+    for (const auto &pair : statically_consistent_assignments) {
+        if (consistent_literals(
+                preconds.dynamic_preconds, pair.first_assignment, pair.second_assignment)) {
+            auto &first_row = adjacency_matrix[pair.first_position];
+            auto &second_row = adjacency_matrix[pair.second_position];
+            first_row[pair.second_position] = 1;
+            second_row[pair.first_position] = 1;
+        }
+    }
+}
+
+vector<LiftedOperatorId> CliqueSuccessorGenerator::applicable_actions_general_case(const ActionSchema &action,
+                                                                                   const DBState &state) {
+    vector<LiftedOperatorId> applicable_actions;
+
+    const auto &preconds = action_precondition.find(action)->second;
+
+    if (!consistent_literals_with_constants(preconds.dynamic_preconds_with_constants)) {
+        return applicable_actions;
+    }
+
+    const auto &action_parameters = action.get_parameters();
+    const auto num_parameters = action_parameters.size();
+
+    const auto &to_vertex_assignment = action_to_vertex_assignment.find(action)->second;
+    const auto &statically_consistent_assignments =
+        action_statically_consistent_assignments.find(action)->second;
+
+    vector<vector<uint32_t>> cliques;
+
+    if (num_parameters == 2) {
+        for (const auto &pair : statically_consistent_assignments) {
+            if (consistent_literals(
+                    preconds.dynamic_preconds, pair.first_assignment, pair.second_assignment)) {
+                cliques.push_back(std::vector<uint32_t>(
+                    {(uint32_t)pair.first_position, (uint32_t)pair.second_position}));
+            }
+        }
+    }
+    else {
+        switch (pivot) {
+        case BronKerboschFirst: {
+            const auto num_vertices = to_vertex_assignment.size();
+            vector<uint32_t> adjacency_list[num_vertices];
+            const auto vertex_ids = create_adjacency_list(preconds,
+                                                          statically_consistent_assignments,
+                                                          num_parameters,
+                                                          adjacency_list,
+                                                          num_vertices);
+            bron_kerbosch_first_pivot(adjacency_list, vertex_ids, num_parameters, cliques);
+            break;
+        }
+
+        case BronKerboschMaxNeighborhood: {
+            const auto num_vertices = to_vertex_assignment.size();
+            vector<uint32_t> adjacency_list[num_vertices];
+            const auto vertex_ids = create_adjacency_list(preconds,
+                                                          statically_consistent_assignments,
+                                                          num_parameters,
+                                                          adjacency_list,
+                                                          num_vertices);
+            bron_kerbosch_max_neighborhood_pivot(
+                adjacency_list, vertex_ids, num_parameters, cliques);
+            break;
+        }
+
+        case BronKerboschMinDifference: {
+            const auto num_vertices = to_vertex_assignment.size();
+            vector<uint32_t> adjacency_list[num_vertices];
+            const auto vertex_ids = create_adjacency_list(preconds,
+                                                          statically_consistent_assignments,
+                                                          num_parameters,
+                                                          adjacency_list,
+                                                          num_vertices);
+            bron_kerbosch_min_difference_pivot(adjacency_list, vertex_ids, num_parameters, cliques);
+            break;
+        }
+
+        case KCliqueKPartite: {
+            const auto num_vertices = to_vertex_assignment.size();
+            std::vector<boost::dynamic_bitset<>> adjacency_matrix(
+                num_vertices, boost::dynamic_bitset<>(num_vertices));
+            create_adjacency_matrix(preconds,
+                                    statically_consistent_assignments,
+                                    num_parameters,
+                                    num_vertices,
+                                    adjacency_matrix);
+
+            const auto &partitions = action_partitions.at(action);
+            algorithms::find_all_k_cliques_in_k_partite_graph(
+                adjacency_matrix, partitions, cliques);
+            break;
+        }
+        }
+    }
+
+    for (const auto &clique : cliques) {
+        GroundAtom assignments(num_parameters);
+        assignments.resize(num_parameters);
+
+        for (const auto vertex_id : clique) {
+            const auto &assignment = to_vertex_assignment.at(vertex_id);
+            assignments[assignment.parameter_index] = assignment.object_index;
+        }
+
+        const auto action_index = action.get_index();
+        const LiftedOperatorId op(action_index, move(assignments));
+
+        // We do not have to check unary and binary relations, however, if the precondition
+        // contains relations of higher arity then we need to check if they hold in the state.
+
+        if (literal_holds(op,
+                          preconds.dynamic_preconds,
+                          preconds.static_preconds,
+                          state,
+                          task.get_static_info(),
+                          3)) {
+            applicable_actions.push_back(op);
+        }
+    }
+
+    return applicable_actions;
+}
+
+std::vector<LiftedOperatorId>
+CliqueSuccessorGenerator::get_applicable_actions(const std::vector<ActionSchema> &actions,
+                                                 const DBState &state) {
+    std::vector<LiftedOperatorId> all_applicable;
+    bool has_built_assignment_sets = false;
+
+    for (const auto &action : actions) {
+        if (!test_nullary_preconditions(action, state)) {
+            continue;
+        }
+
+        const auto &action_parameters = action.get_parameters();
+        const auto num_parameters = action_parameters.size();
+
+        if (num_parameters == 0) {
+            const auto &applicable = applicable_actions_nullary_case(action, state);
+            all_applicable.insert(all_applicable.end(), applicable.begin(), applicable.end());
+        }
+        else if (num_parameters == 1) {
+            const auto &applicable = applicable_actions_unary_case(action, state);
+            all_applicable.insert(all_applicable.end(), applicable.begin(), applicable.end());
+        }
+        else {
+
+            if (!has_built_assignment_sets) {
+                build_assignment_sets(state);
+                has_built_assignment_sets = true;
+            }
+
+            const auto &applicable = applicable_actions_general_case(action, state);
+            all_applicable.insert(all_applicable.end(), applicable.begin(), applicable.end());
+        }
+    }
+
+    return all_applicable;
+}
+
+vector<LiftedOperatorId>
+CliqueSuccessorGenerator::get_applicable_actions(const ActionSchema &action, const DBState &state) {
+    if (!test_nullary_preconditions(action, state)) {
+        return vector<LiftedOperatorId>();
+    }
+
+    const auto &action_parameters = action.get_parameters();
+    const auto num_parameters = action_parameters.size();
+
+    if (num_parameters == 0) {
+        return applicable_actions_nullary_case(action, state);
+    }
+    else if (num_parameters == 1) {
+        return applicable_actions_unary_case(action, state);
+    }
+    else {
+        build_assignment_sets(state);
+        return applicable_actions_general_case(action, state);
+    }
+}

--- a/src/search/successor_generators/clique_successor_generator.h
+++ b/src/search/successor_generators/clique_successor_generator.h
@@ -1,0 +1,169 @@
+#ifndef SEARCH_CLIQUE_H
+#define SEARCH_CLIQUE_H
+
+#include "successor_generator.h"
+
+#include "../action.h"
+#include "../action_schema.h"
+#include "../states/state.h"
+#include "../task.h"
+
+#include <algorithm>
+#include <boost/dynamic_bitset.hpp>
+#include <map>
+#include <set>
+#include <unordered_map>
+#include <vector>
+
+class Task;
+
+struct Assignment {
+    int parameter_index;
+    int object_index;
+
+    Assignment(int parameter_index, int object_index)
+        : parameter_index(parameter_index), object_index(object_index) {
+    }
+};
+
+struct AssignmentPair {
+    std::size_t first_position;
+    std::size_t second_position;
+    Assignment first_assignment;
+    Assignment second_assignment;
+
+    AssignmentPair(std::size_t first_position,
+                   const Assignment &first_assignment,
+                   std::size_t second_position,
+                   const Assignment &second_assignment)
+        : first_position(first_position),
+          second_position(second_position),
+          first_assignment(first_assignment),
+          second_assignment(second_assignment) {
+    }
+};
+
+struct Precondition {
+    std::vector<Atom> static_preconds;
+    std::vector<Atom> dynamic_preconds;
+    std::vector<Atom> dynamic_preconds_with_constants;
+
+    Precondition(const std::vector<Atom> &static_preconds,
+                 const std::vector<Atom> &dynamic_preconds)
+        : static_preconds(static_preconds),
+          dynamic_preconds(dynamic_preconds),
+          dynamic_preconds_with_constants() {
+        std::sort(this->dynamic_preconds.begin(),
+                  this->dynamic_preconds.end(),
+                  [](const Atom &lhs, const Atom &rhs) -> bool {
+                      size_t lhs_num_free = 0;
+                      size_t rhs_num_free = 0;
+
+                      for (const auto &parameter : lhs.get_arguments()) {
+                          if (!parameter.is_constant()) {
+                              ++lhs_num_free;
+                          }
+                      }
+
+                      for (const auto &parameter : rhs.get_arguments()) {
+                          if (!parameter.is_constant()) {
+                              ++rhs_num_free;
+                          }
+                      }
+
+                      return lhs_num_free > rhs_num_free;
+                  });
+
+        for (const auto &atom : this->dynamic_preconds) {
+            bool has_constant = false;
+            for (const auto &parameter : atom.get_arguments()) {
+                if (parameter.is_constant()) {
+                    has_constant = true;
+                    break;
+                }
+            }
+
+            if (has_constant) {
+                this->dynamic_preconds_with_constants.push_back(atom);
+            }
+        }
+    }
+};
+
+enum CliquePivot {
+    BronKerboschFirst,
+    BronKerboschMaxNeighborhood,
+    BronKerboschMinDifference,
+    KCliqueKPartite,
+};
+
+class CliqueSuccessorGenerator : public SuccessorGenerator {
+private:
+    const Task &task;
+    const CliquePivot pivot;
+    std::unordered_map<ActionSchema, std::unordered_map<Parameter, std::set<Object>>> action_objects_by_parameter_type;
+    std::unordered_map<ActionSchema, std::vector<Assignment>> action_to_vertex_assignment;
+    std::unordered_map<ActionSchema, std::vector<std::vector<std::size_t>>> action_partitions;
+    std::unordered_map<ActionSchema, std::vector<AssignmentPair>> action_statically_consistent_assignments;
+    std::unordered_map<ActionSchema, Precondition> action_precondition;
+
+    // Cache certain data-structures to avoid dynamic allocations
+    std::vector<std::vector<bool>> assignment_sets;
+
+    void build_assignment_sets(const DBState &atoms);
+
+    bool consistent_literals(const std::vector<Atom> &literals,
+                             const Assignment &first_assignment,
+                             const Assignment &second_assignment);
+
+    bool consistent_literals_with_constants(const std::vector<Atom> &literals);
+
+    bool test_nullary_preconditions(const ActionSchema &action, const DBState &state);
+
+    std::vector<uint32_t> create_adjacency_list(const Precondition &preconds,
+                                                const std::vector<AssignmentPair> &statically_consistent_assignments,
+                                                std::size_t num_parameters,
+                                                std::vector<uint32_t> *adjacency_list,
+                                                std::size_t num_vertices);
+
+    void create_adjacency_matrix(const Precondition &preconds,
+                                 const std::vector<AssignmentPair> &statically_consistent_assignments,
+                                 std::size_t num_parameters,
+                                 std::size_t num_vertices,
+                                 std::vector<boost::dynamic_bitset<>> &adjacency_matrix);
+
+    std::vector<LiftedOperatorId> applicable_actions_nullary_case(const ActionSchema &action,
+                                                                  const DBState &state);
+
+    std::vector<LiftedOperatorId> applicable_actions_unary_case(const ActionSchema &action,
+                                                                const DBState &state);
+
+    std::vector<LiftedOperatorId> applicable_actions_general_case(const ActionSchema &action,
+                                                                  const DBState &state);
+
+public:
+    explicit CliqueSuccessorGenerator(const Task &task, const CliquePivot &pivot);
+
+    std::vector<LiftedOperatorId> get_applicable_actions(const std::vector<ActionSchema> &actions,
+                                                         const DBState &state) override;
+
+    std::vector<LiftedOperatorId> get_applicable_actions(const ActionSchema &action,
+                                                         const DBState &state) override;
+
+    const GroundAtom tuple_to_atom(const std::vector<int> &tuple, const Atom &eff);
+
+    void apply_nullary_effects(const ActionSchema &action, std::vector<bool> &new_nullary_atoms);
+
+    void apply_ground_action_effects(const ActionSchema &action,
+                                     std::vector<Relation> &new_relation);
+
+    void apply_lifted_action_effects(const ActionSchema &action,
+                                     const std::vector<int> &tuple,
+                                     std::vector<Relation> &new_relation);
+
+    DBState generate_successor(const LiftedOperatorId &op,
+                               const ActionSchema &action,
+                               const DBState &state) override;
+};
+
+#endif  // SEARCH_CLIQUE_H

--- a/src/search/successor_generators/clique_successor_generator_apply.cc
+++ b/src/search/successor_generators/clique_successor_generator_apply.cc
@@ -1,0 +1,120 @@
+#include "clique_bron_kerbosch.h"
+#include "clique_help_functions.h"
+#include "clique_successor_generator.h"
+
+#include <cassert>
+#include <limits>
+#include <unordered_map>
+#include <vector>
+
+using namespace std;
+
+/*
+ * The code for applying actions is copied from generic_join_successor.cc
+ */
+
+void CliqueSuccessorGenerator::apply_nullary_effects(const ActionSchema &action,
+                                                     vector<bool> &new_nullary_atoms) {
+    /*
+     * Loop over positive and negative nullary effects and apply them accordingly
+     * to the state.
+     */
+    for (size_t i = 0; i < action.get_negative_nullary_effects().size(); ++i) {
+        if (action.get_negative_nullary_effects()[i]) {
+            new_nullary_atoms[i] = false;
+        }
+    }
+
+    for (size_t i = 0; i < action.get_positive_nullary_effects().size(); ++i) {
+        if (action.get_positive_nullary_effects()[i]) {
+            new_nullary_atoms[i] = true;
+            add_to_added_atoms(i, GroundAtom());
+        }
+    }
+}
+
+void CliqueSuccessorGenerator::apply_ground_action_effects(const ActionSchema &action,
+                                                           vector<Relation> &new_relation) {
+    for (const Atom &eff : action.get_effects()) {
+        GroundAtom ga;
+        for (const Argument &a : eff.get_arguments()) {
+            // Create ground atom for each effect given the instantiation
+            assert(a.is_constant());
+            ga.push_back(a.get_index());
+        }
+
+        assert(eff.get_predicate_symbol_idx() ==
+               new_relation[eff.get_predicate_symbol_idx()].predicate_symbol);
+
+        if (eff.is_negated()) {
+            // If ground effect is negated, remove it from relation
+            new_relation[eff.get_predicate_symbol_idx()].tuples.erase(ga);
+        }
+        else {
+            // If ground effect is not in the state, we add it
+
+            new_relation[eff.get_predicate_symbol_idx()].tuples.insert(ga);
+            add_to_added_atoms(eff.get_predicate_symbol_idx(), ga);
+        }
+    }
+}
+
+const GroundAtom CliqueSuccessorGenerator::tuple_to_atom(const vector<int> &tuple, const Atom &eff) {
+    GroundAtom ground_atom;
+    ground_atom.reserve(eff.get_arguments().size());
+    for (auto argument : eff.get_arguments()) {
+        if (!argument.is_constant()) {
+            ground_atom.push_back(tuple[argument.get_index()]);
+        }
+        else {
+            ground_atom.push_back(argument.get_index());
+        }
+    }
+
+    // Sanity check: check that all positions of the tuple were initialized
+    assert(find(ground_atom.begin(), ground_atom.end(), -1) == ground_atom.end());
+
+    return ground_atom;
+}
+
+void CliqueSuccessorGenerator::apply_lifted_action_effects(const ActionSchema &action,
+                                                           const vector<int> &tuple,
+                                                           vector<Relation> &new_relation) {
+    for (const Atom &eff : action.get_effects()) {
+        GroundAtom ga = tuple_to_atom(tuple, eff);
+        assert(eff.get_predicate_symbol_idx() ==
+               new_relation[eff.get_predicate_symbol_idx()].predicate_symbol);
+        if (eff.is_negated()) {
+            // Remove from relation
+            new_relation[eff.get_predicate_symbol_idx()].tuples.erase(ga);
+        }
+        else {
+            int predicate_symbol_idx = eff.get_predicate_symbol_idx();
+            if (find(new_relation[predicate_symbol_idx].tuples.begin(),
+                     new_relation[predicate_symbol_idx].tuples.end(),
+                     ga) == new_relation[predicate_symbol_idx].tuples.end()) {
+                // If ground atom is not in the state, we add it
+                new_relation[eff.get_predicate_symbol_idx()].tuples.insert(ga);
+                add_to_added_atoms(eff.get_predicate_symbol_idx(), ga);
+            }
+        }
+    }
+}
+
+DBState CliqueSuccessorGenerator::generate_successor(const LiftedOperatorId &op,
+                                                     const ActionSchema &action,
+                                                     const DBState &state) {
+    added_atoms.clear();
+    vector<bool> new_nullary_atoms(state.get_nullary_atoms());
+    vector<Relation> new_relation(state.get_relations());
+    apply_nullary_effects(action, new_nullary_atoms);
+
+    if (action.is_ground()) {
+        apply_ground_action_effects(action, new_relation);
+    }
+    else {
+        apply_lifted_action_effects(action, op.get_instantiation(), new_relation);
+    }
+
+    return DBState(std::move(new_relation), std::move(new_nullary_atoms));
+}

--- a/src/search/successor_generators/generic_join_successor.cc
+++ b/src/search/successor_generators/generic_join_successor.cc
@@ -495,6 +495,19 @@ std::vector<LiftedOperatorId> GenericJoinSuccessor::get_applicable_actions(
     return applicable;
 }
 
+std::vector<LiftedOperatorId> GenericJoinSuccessor::get_applicable_actions(
+            const std::vector<ActionSchema> &actions, const DBState &state)
+{
+    std::vector<LiftedOperatorId> all_applicable_actions;
+
+    for (const auto& action : actions) {
+        const auto applicable_actions = get_applicable_actions(action, state);
+        all_applicable_actions.reserve(all_applicable_actions.size() + applicable_actions.size());
+        all_applicable_actions.insert(all_applicable_actions.end(), applicable_actions.cbegin(), applicable_actions.cend());
+    }
+
+    return all_applicable_actions;
+}
 
 /**
  *    This action generates the ground atom produced by an atomic effect given an instantiation of

--- a/src/search/successor_generators/generic_join_successor.h
+++ b/src/search/successor_generators/generic_join_successor.h
@@ -64,6 +64,9 @@ public:
     std::vector<LiftedOperatorId> get_applicable_actions(
             const ActionSchema &action, const DBState &state) override;
 
+    std::vector<LiftedOperatorId> get_applicable_actions(
+            const std::vector<ActionSchema> &actions, const DBState &state) override;
+
     const GroundAtom tuple_to_atom(const std::vector<int> &tuple, const Atom &eff);
 
     const std::unordered_set<GroundAtom, TupleHash>

--- a/src/search/successor_generators/successor_generator.h
+++ b/src/search/successor_generators/successor_generator.h
@@ -38,6 +38,18 @@ public:
             const ActionSchema &action, const DBState &state) = 0;
 
     /**
+     * Compute the instantiations of the given action schemas that are applicable in
+     * the given state.
+     *
+     * @param actions: The action schemas
+     * @param state: The state on which we want to compute applicability
+     * @return A vector of IDs representing each of them a single applicable
+     * instantiation of an action schema.
+     */
+    virtual std::vector<LiftedOperatorId> get_applicable_actions(
+            const std::vector<ActionSchema> &actions, const DBState &state) = 0;
+
+    /**
      * Generate the state that results from applying the given action to the given state.
      */
     virtual DBState generate_successor(const LiftedOperatorId &op,

--- a/src/search/successor_generators/successor_generator_factory.cc
+++ b/src/search/successor_generators/successor_generator_factory.cc
@@ -6,6 +6,7 @@
 #include "ordered_join_successor.h"
 #include "random_successor.h"
 #include "yannakakis.h"
+#include "clique_successor_generator.h"
 
 #include "../database/table.h"
 
@@ -35,6 +36,12 @@ SuccessorGenerator *SuccessorGeneratorFactory::create(const std::string &method,
     }
     else if (boost::iequals(method, "yannakakis")) {
         return new YannakakisSuccessorGenerator(task);
+    }
+    else if (boost::iequals(method, "clique_bk")) {
+        return new CliqueSuccessorGenerator(task, BronKerboschFirst);
+    }
+    else if (boost::iequals(method, "clique_kckp")) {
+        return new CliqueSuccessorGenerator(task, KCliqueKPartite);
     }
     else {
         std::cerr << "Invalid successor generator method \"" << method << "\"" << std::endl;


### PR DESCRIPTION
Add the lifted successor generator from the paper titled 'Simon Ståhlberg, Lifted Successor Generation by Maximum Clique Enumeration, ECAI 2023.'

I have tried to change as few files as possible while adhering to the coding style of the repository. However, there are a few notable changes:

* In `src/search/[action_schema | object | structures].h`, I have implemented comparison operators and hash functions.
* In `src/search_engines/**.cc`, the iteration over action schemas has been replaced. Instead, the successor generator is now provided with a list of action schemas. This change was made because some computations by the new lifted successor generator are shared among all action schemas. As far as I can tell, the performance impact of this change is not measurable. (The diff is a bit messy because of indentation.)

Let me know if any changes need to be made for this commit to be merged.
