### PR TITLE
Fix action effect rule costs

### DIFF
--- a/src/search/datalog/datalog.cc
+++ b/src/search/datalog/datalog.cc
@@ -71,7 +71,7 @@ void Datalog::generate_action_effect_rules(const ActionSchema &schema, Annotatio
             continue;
         DatalogAtom effect(eff);
         std::unique_ptr<Annotation> ann = annotation_generator(-1, task);
-        rules.emplace_back(make_unique<GenericRule>(schema.get_cost(), eff, body, std::move(ann)));
+        rules.emplace_back(make_unique<GenericRule>(0, eff, body, std::move(ann)));
     }
     const vector<bool> &nullary_predicates_in_eff = schema.get_positive_nullary_effects();
     vector<size_t> nullary_effects;
@@ -79,7 +79,7 @@ void Datalog::generate_action_effect_rules(const ActionSchema &schema, Annotatio
     for (size_t eff_idx : nullary_effects) {
         DatalogAtom eff(Arguments(), eff_idx, false);
         std::unique_ptr<Annotation> ann = annotation_generator(-1, task);
-        rules.emplace_back(make_unique<GenericRule>(schema.get_cost(), eff, body, std::move(ann), schema.get_index()));
+        rules.emplace_back(make_unique<GenericRule>(0, eff, body, std::move(ann), schema.get_index()));
     }
 }
 


### PR DESCRIPTION
In the ICAPS21 and AAAI22 paper, action effect rules are defined to have a cost of 0, which doesn't match up with the current code. This shouldn't actually matter, since the action predicate removal transformation sets rule weights correctly, and this transformation is always applied. It's still nice to fix it though.