### PR TITLE
Cleanup hashing of states and datalog

### DIFF
--- a/src/search/datalog/arguments.h
+++ b/src/search/datalog/arguments.h
@@ -3,6 +3,8 @@
 
 #include "term.h"
 
+#include "../utils/hash.h"
+
 #include <cassert>
 #include <vector>
 
@@ -50,12 +52,7 @@ class HashArguments {
 public:
     std::size_t operator()(const Arguments &f) const
     {
-        // 0x9e3779b9 = 2^32 / phi (golden ratio); see Knuth TAOCP Vol. 3, Sec. 6.4
-        std::size_t seed = 0;
-        for (auto it = f.begin(); it != f.end(); ++it) {
-            seed ^= std::hash<Term>{}(*it) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-        }
-        return seed;
+        return utils::hash_range(f.begin(), f.end());
     }
 };
 

--- a/src/search/states/state.cc
+++ b/src/search/states/state.cc
@@ -13,23 +13,19 @@ void DBState::add_tuple(int relation, const GroundAtom &args)
 
 std::size_t hash_value(const DBState &s)
 {
-    std::size_t seed = 0;
+    utils::HashState hash_state;
     for (bool b : s.nullary_atoms) {
-        utils::hash_combine(seed, static_cast<std::size_t>(b));
+        utils::feed(hash_state, static_cast<unsigned int>(b));
     }
     for (const Relation &r : s.relations) {
-        std::vector<std::size_t> x;
-        for (const GroundAtom &vga : r.tuples) {
-            std::size_t aux_seed = vga.size();
-            // 0x9e3779b9 = 2^32 / phi (golden ratio); see Knuth TAOCP Vol. 3, Sec. 6.4
-            for (auto &i : vga)
-                aux_seed ^= i + 0x9e3779b9 + (aux_seed << 6) + (aux_seed >> 2);
-            x.push_back(aux_seed);
+        // Use addition (commutative) to combine per-atom hashes so that
+        // iteration order over the unordered_set does not matter.  O(n)
+        // instead of the previous O(n log n) sort.
+        std::size_t relation_hash = 0;
+        for (const GroundAtom &ga : r.tuples) {
+            relation_hash += utils::get_hash(ga);
         }
-        std::sort(x.begin(), x.end());
-        for (std::size_t e : x) {
-            utils::hash_combine(seed, e);
-        }
+        utils::feed(hash_state, static_cast<std::uint64_t>(relation_hash));
     }
-    return seed;
+    return hash_state.get_hash32();
 }

--- a/src/search/states/state.cc
+++ b/src/search/states/state.cc
@@ -27,5 +27,5 @@ std::size_t hash_value(const DBState &s)
         }
         utils::feed(hash_state, static_cast<std::uint64_t>(relation_hash));
     }
-    return hash_state.get_hash32();
+    return hash_state.get_hash64();
 }


### PR DESCRIPTION
Hashing cleanups in the state and datalog:

  - **Use O(n) state hash** (`3f99063`): replace the quadratic state hash in `states/state.cc`  with a linear pass.
  - **Tighten hash consistency** (`ab2b581`): change `datalog/arguments.h` and `states/state.cc` hash calls.