### PR TITLE
Speed up grounding-based heuristic evaluation

### DIFF
--- a/src/search/datalog/datalog.cc
+++ b/src/search/datalog/datalog.cc
@@ -8,6 +8,7 @@
 #include "transformations/goal_rule.h"
 #include "transformations/normal_form.h"
 #include "transformations/remove_equivalent_rules.h"
+#include "transformations/static_stratum.h"
 #include "transformations/variable_renaming.h"
 
 #include <iostream>

--- a/src/search/datalog/datalog.h
+++ b/src/search/datalog/datalog.h
@@ -96,6 +96,8 @@ public:
 
     void remove_action_predicates(AnnotationGenerator &annotation_generator, const Task &task);
 
+    void materialize_static_stratum(const Task &task, int heuristic_type);
+
     void convert_rules_to_normal_form(const Task &task);
 
     bool remove_duplicate_rules();

--- a/src/search/datalog/datalog.h
+++ b/src/search/datalog/datalog.h
@@ -152,6 +152,14 @@ public:
         facts.clear();
     }
 
+    // Drop every fact after the persistent base prefix (see WeightedGrounder)
+    // while keeping the allocation. This only ever shrinks the vector; erase
+    // instead of resize because Fact has no default constructor.
+    void truncate_facts(int num_kept) {
+        assert(num_kept <= int(facts.size()));
+        facts.erase(facts.begin() + num_kept, facts.end());
+    }
+
     void print_statistics() {
         std::cout << "Total number of static atoms in the EDB: " << permanent_edb.size() << std::endl;
         std::cout << "Total number of rules: " << rules.size() << std::endl;

--- a/src/search/datalog/grounder/weighted_grounder.cc
+++ b/src/search/datalog/grounder/weighted_grounder.cc
@@ -8,6 +8,7 @@
 
 #include <deque>
 #include <limits>
+#include <unordered_set>
 #include <vector>
 
 using namespace std;
@@ -15,19 +16,50 @@ using namespace std;
 namespace datalog {
 
 int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, int goal_predicate) {
-    phmap::flat_hash_set<Fact> reached_facts;
     std::vector<Fact> newfacts;
 
     queue_pushes = 0;
     atoms_produced = 0;
 
-    // Reset of data structures
-    Fact::next_fact_index = 0;
+    if (!base_initialized) {
+        // One-time split of the EDB into the persistent base and the
+        // improvable remainder (see header comment).
+        std::unordered_set<int> derived_preds;
+        for (const auto &rule : datalog.get_rules()) {
+            derived_preds.insert(rule->get_effect().get_predicate_index());
+        }
+        Fact::next_fact_index = 0;
+        for (const Fact &f : datalog.get_permanent_edb()) {
+            if (derived_preds.count(f.get_predicate_index())) {
+                improvable_edb.push_back(f);
+            }
+            else {
+                Fact f2 = f;
+                f2.set_fact_index();
+                datalog.insert_fact(f2);
+            }
+        }
+        num_base_facts = Fact::next_fact_index;
+        base_initialized = true;
+    }
+
+    // Reset of data structures: drop everything after the persistent base.
+    datalog.truncate_facts(num_base_facts);
+    Fact::next_fact_index = num_base_facts;
+    reached_facts.clear();
 
     q.clear();
     best_achievers.clear();
 
-    for (const Fact &f : datalog.get_permanent_edb()) {
+    for (int i = 0; i < num_base_facts; ++i) {
+        q.push(datalog.get_fact_by_index(i).get_cost(), i);
+        queue_pushes++;
+        cumulative_queue_pushes++;
+        atoms_produced++;
+        cumulative_atoms_produced++;
+    }
+
+    for (const Fact &f : improvable_edb) {
         Fact f2 = f;
         f2.set_fact_index();
         q.push(f.get_cost(), f2.get_fact_index());

--- a/src/search/datalog/grounder/weighted_grounder.cc
+++ b/src/search/datalog/grounder/weighted_grounder.cc
@@ -15,6 +15,109 @@ using namespace std;
 
 namespace datalog {
 
+/*
+ * Exact inside (cheapest derivation) and outside (cheapest completion of a
+ * goal derivation) costs of the predicate-level abstraction. The abstract
+ * hypergraph has one node per predicate and one hyperedge per rule; both
+ * fixpoints are Bellman-Ford style loops over the rules, which is plenty on a
+ * graph this small (costs are monotone and integral, so they terminate).
+ */
+void WeightedGrounder::compute_abstract_costs(Datalog &datalog,
+                                              const std::vector<Fact> &state_facts,
+                                              int goal_predicate) {
+    size_t num_preds = 0;
+    for (const auto &rule : datalog.get_rules()) {
+        num_preds = std::max(num_preds, size_t(rule->get_effect().get_predicate_index()) + 1);
+        for (const DatalogAtom &b : rule->get_conditions()) {
+            num_preds = std::max(num_preds, size_t(b.get_predicate_index()) + 1);
+        }
+    }
+    for (const Fact &f : datalog.get_permanent_edb()) {
+        num_preds = std::max(num_preds, size_t(f.get_predicate_index()) + 1);
+    }
+    for (const Fact &f : state_facts) {
+        num_preds = std::max(num_preds, size_t(f.get_predicate_index()) + 1);
+    }
+    num_preds = std::max(num_preds, size_t(goal_predicate) + 1);
+
+    abstract_inside.assign(num_preds, ABSTRACT_INF);
+    abstract_outside.assign(num_preds, ABSTRACT_INF);
+
+    // Base: the cheapest initial fact of each predicate. The persistent base
+    // lives in the fact vector prefix; the improvable EDB facts and the state
+    // facts arrive as arguments.
+    for (int i = 0; i < num_base_facts; ++i) {
+        const Fact &f = datalog.get_fact_by_index(i);
+        int &c = abstract_inside[f.get_predicate_index()];
+        c = std::min(c, f.get_cost());
+    }
+    for (const Fact &f : improvable_edb) {
+        int &c = abstract_inside[f.get_predicate_index()];
+        c = std::min(c, f.get_cost());
+    }
+    for (const Fact &f : state_facts) {
+        int &c = abstract_inside[f.get_predicate_index()];
+        c = std::min(c, f.get_cost());
+    }
+
+    const auto &rules = datalog.get_rules();
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto &rule : rules) {
+            int body_agg = 0;
+            bool infinite = false;
+            for (const DatalogAtom &b : rule->get_conditions()) {
+                int c = abstract_inside[b.get_predicate_index()];
+                if (c >= ABSTRACT_INF) {
+                    infinite = true;
+                    break;
+                }
+                body_agg = aggregation_function(body_agg, c);
+            }
+            if (infinite) continue;
+            int head_cost = body_agg + rule->get_weight();
+            int &c = abstract_inside[rule->get_effect().get_predicate_index()];
+            if (head_cost < c) {
+                c = head_cost;
+                changed = true;
+            }
+        }
+    }
+
+    abstract_outside[goal_predicate] = 0;
+    changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto &rule : rules) {
+            int out_head = abstract_outside[rule->get_effect().get_predicate_index()];
+            if (out_head >= ABSTRACT_INF) continue;
+            const std::vector<DatalogAtom> &body = rule->get_conditions();
+            for (size_t i = 0; i < body.size(); ++i) {
+                int others_agg = 0;
+                bool infinite = false;
+                for (size_t j = 0; j < body.size(); ++j) {
+                    if (j == i) continue;
+                    int c = abstract_inside[body[j].get_predicate_index()];
+                    if (c >= ABSTRACT_INF) {
+                        infinite = true;
+                        break;
+                    }
+                    others_agg = aggregation_function(others_agg, c);
+                }
+                if (infinite) continue;
+                int candidate =
+                    aggregation_function(out_head, others_agg + rule->get_weight());
+                int &out = abstract_outside[body[i].get_predicate_index()];
+                if (candidate < out) {
+                    out = candidate;
+                    changed = true;
+                }
+            }
+        }
+    }
+}
+
 int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, int goal_predicate) {
     std::vector<Fact> newfacts;
 
@@ -51,35 +154,48 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
     q.clear();
     best_achievers.clear();
 
+    if (goal_predicate >= 0) {
+        compute_abstract_costs(datalog, state_facts, goal_predicate);
+    }
+    else {
+        abstract_outside.clear();
+    }
+
     for (int i = 0; i < num_base_facts; ++i) {
-        q.push(datalog.get_fact_by_index(i).get_cost(), i);
-        queue_pushes++;
-        cumulative_queue_pushes++;
         atoms_produced++;
         cumulative_atoms_produced++;
+        int priority = priority_of(datalog.get_fact_by_index(i));
+        if (priority >= ABSTRACT_INF) continue;
+        q.push(priority, i);
+        queue_pushes++;
+        cumulative_queue_pushes++;
     }
 
     for (const Fact &f : improvable_edb) {
         Fact f2 = f;
         f2.set_fact_index();
-        q.push(f.get_cost(), f2.get_fact_index());
-        queue_pushes++;
-        cumulative_queue_pushes++;
         atoms_produced++;
         cumulative_atoms_produced++;
         datalog.insert_fact(f2);
         reached_facts.insert(f2);
+        int priority = priority_of(f2);
+        if (priority >= ABSTRACT_INF) continue;
+        q.push(priority, f2.get_fact_index());
+        queue_pushes++;
+        cumulative_queue_pushes++;
     }
 
     for (Fact &f : state_facts) {
         f.set_fact_index();
-        q.push(f.get_cost(), f.get_fact_index());
-        queue_pushes++;
-        cumulative_queue_pushes++;
         atoms_produced++;
         cumulative_atoms_produced++;
         datalog.insert_fact(f);
         reached_facts.insert(f);
+        int priority = priority_of(f);
+        if (priority >= ABSTRACT_INF) continue;
+        q.push(priority, f.get_fact_index());
+        queue_pushes++;
+        cumulative_queue_pushes++;
     }
 
     // EDB + state facts now own the contiguous index range [0, num_initial_facts).
@@ -100,7 +216,7 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
             datalog.backchain_from_goal(popped_fact, num_initial_facts);
             return popped_fact.get_cost();
         }
-        if (popped_fact.get_cost() < cost) {
+        if (priority_of(popped_fact) < cost) {
             continue;
         }
         int predicate_index = popped_fact.get_predicate_index();
@@ -136,7 +252,11 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
                 //datalog.output_atom(new_fact);
                 //std::cout << std::endl << std::flush;
                 if (id!=HAS_CHEAPER_PATH) {
-                    q.push(new_fact.get_cost(), id);
+                    // Duplicate detection above already recorded the fact;
+                    // queue it only if it can still join a goal derivation.
+                    int priority = priority_of(new_fact);
+                    if (priority >= ABSTRACT_INF) continue;
+                    q.push(priority, id);
                     queue_pushes++;
                     cumulative_queue_pushes++;
                 }

--- a/src/search/datalog/grounder/weighted_grounder.cc
+++ b/src/search/datalog/grounder/weighted_grounder.cc
@@ -32,7 +32,9 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
         f2.set_fact_index();
         q.push(f.get_cost(), f2.get_fact_index());
         queue_pushes++;
+        cumulative_queue_pushes++;
         atoms_produced++;
+        cumulative_atoms_produced++;
         datalog.insert_fact(f2);
         reached_facts.insert(f2);
     }
@@ -41,7 +43,9 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
         f.set_fact_index();
         q.push(f.get_cost(), f.get_fact_index());
         queue_pushes++;
+        cumulative_queue_pushes++;
         atoms_produced++;
+        cumulative_atoms_produced++;
         datalog.insert_fact(f);
         reached_facts.insert(f);
     }
@@ -102,6 +106,7 @@ int WeightedGrounder::ground(Datalog &datalog, std::vector<Fact> &state_facts, i
                 if (id!=HAS_CHEAPER_PATH) {
                     q.push(new_fact.get_cost(), id);
                     queue_pushes++;
+                    cumulative_queue_pushes++;
                 }
             }
         }
@@ -113,6 +118,7 @@ int WeightedGrounder::is_cheapest_path_to_achieve_fact(Fact &new_fact,
                                                        phmap::flat_hash_set<Fact> &reached_facts,
                                                        Datalog &lp) {
     atoms_produced++;
+    cumulative_atoms_produced++;
     // Fuse the membership probe and the insert into one hash+probe pass. The old
     // code did find() then, on a miss, a second insert() (two hashes of the whole
     // argument tuple per new fact). lazy_emplace() probes once and constructs the

--- a/src/search/datalog/grounder/weighted_grounder.cc
+++ b/src/search/datalog/grounder/weighted_grounder.cc
@@ -106,8 +106,15 @@ void WeightedGrounder::compute_abstract_costs(Datalog &datalog,
                     others_agg = aggregation_function(others_agg, c);
                 }
                 if (infinite) continue;
-                int candidate =
-                    aggregation_function(out_head, others_agg + rule->get_weight());
+                // Rule weights add along a derivation chain under both
+                // aggregations (cost(head) = w (+/max) bodies telescopes to
+                // goal >= g(b) + sum of chain weights), so the outside cost
+                // is a weight sum in both cases; sibling inside costs join it
+                // only under the additive aggregation. The sibling scan above
+                // still runs for h^max: a rule with an underivable body atom
+                // (infinite inside) can never fire and propagates no demand.
+                int candidate = out_head + rule->get_weight() +
+                                (heuristic_type == H_ADD ? others_agg : 0);
                 int &out = abstract_outside[body[i].get_predicate_index()];
                 if (candidate < out) {
                     out = candidate;

--- a/src/search/datalog/grounder/weighted_grounder.h
+++ b/src/search/datalog/grounder/weighted_grounder.h
@@ -55,14 +55,22 @@ class WeightedGrounder : public Grounder {
 
     // A* for lightest derivations (Felzenszwalb & McAllester): each call
     // computes exact inside/outside costs of the predicate-level abstraction
-    // (one node per predicate, one hyperedge per rule) and orders the queue
-    // by f = g + outside[predicate]. Outside estimates from an abstraction
-    // are admissible and monotone, so the goal still pops at its exact cost;
-    // a predicate with infinite outside cost can never take part in a goal
-    // derivation, so its facts skip the queue entirely.
+    // (one node per predicate, one hyperedge per rule). A predicate with
+    // infinite outside cost can never take part in a goal derivation, so its
+    // facts skip the queue under either ordering policy. Ordering the queue
+    // by f = g + outside truncates the evaluation earlier; outside estimates
+    // from an abstraction are admissible and monotone, so the goal still
+    // pops at its exact cost, and f = g + outside holds under both
+    // aggregations: chain weights add along a derivation even under h^max.
+    // Heuristics that extract achievers (h^ff, h^rff) keep the plain cost
+    // order instead: the f order pops equally cheap derivations in a
+    // different sequence, records different (equally valid) achievers, and
+    // thereby changes the extracted relaxed plan, whereas the cost order
+    // reproduces the plain Dijkstra grounder's achievers exactly.
     static constexpr int ABSTRACT_INF = std::numeric_limits<int>::max() / 4;
     std::vector<int> abstract_inside;
     std::vector<int> abstract_outside;
+    bool order_by_outside;
 
     void compute_abstract_costs(Datalog &datalog,
                                 const std::vector<Fact> &state_facts,
@@ -71,13 +79,10 @@ class WeightedGrounder : public Grounder {
     int priority_of(const Fact &fact) const {
         int pred = fact.get_predicate_index();
         // Goal-less evaluation (static-stratum materialization) computes no
-        // outside costs and runs as a plain Dijkstra. f = g + outside holds
-        // under both aggregations: chain weights add along a derivation even
-        // under h^max, and the max across a rule's preconditions falls out of
-        // the queue itself, since every fact carries its own f.
+        // outside costs and runs as a plain Dijkstra either way.
         int out = pred < int(abstract_outside.size()) ? abstract_outside[pred] : 0;
         if (out >= ABSTRACT_INF) return ABSTRACT_INF;
-        return fact.get_cost() + out;
+        return order_by_outside ? fact.get_cost() + out : fact.get_cost();
     }
 
     // Reused across join() calls so the per-call join key is built in place
@@ -110,7 +115,8 @@ protected:
     }
 
 public:
-    WeightedGrounder(const Datalog &lp, int h)  {
+    WeightedGrounder(const Datalog &lp, int h, bool order_by_outside)
+        : order_by_outside(order_by_outside) {
         create_rule_matcher(lp);
         heuristic_type = h;
         queue_pushes = 0;

--- a/src/search/datalog/grounder/weighted_grounder.h
+++ b/src/search/datalog/grounder/weighted_grounder.h
@@ -10,7 +10,9 @@
 #include "../../algorithms/priority_queues.h"
 #include "../../parallel_hashmap/phmap.h"
 
+#include <algorithm>
 #include <iostream>
+#include <limits>
 #include <unordered_set>
 #include <vector>
 
@@ -35,6 +37,21 @@ class WeightedGrounder : public Grounder {
     // per-evaluation hash set of their indices.
     int num_initial_facts;
     std::vector<int> best_achievers;
+
+    // Persistent base: EDB facts whose predicate no rule derives can never
+    // collide with a runtime-derived fact, so the first ground() call inserts
+    // them into the fact vector once (indices [0, num_base_facts)) and they
+    // never enter the reached-facts set; later calls re-push their indices
+    // without re-copying or re-hashing them. EDB facts of derivable
+    // predicates (kept in improvable_edb) get the classic per-call treatment,
+    // because a runtime derivation may improve their cost.
+    bool base_initialized;
+    int num_base_facts;
+    std::vector<Fact> improvable_edb;
+
+    // Member instead of a ground() local so its capacity survives across
+    // calls (state facts + derived facts only; see num_base_facts).
+    phmap::flat_hash_set<Fact> reached_facts;
 
     // Reused across join() calls so the per-call join key is built in place
     // instead of allocating a fresh vector every time (join() is the hottest
@@ -74,6 +91,8 @@ public:
         cumulative_atoms_produced = 0;
         cumulative_queue_pushes = 0;
         total_number_of_facts = 0;
+        base_initialized = false;
+        num_base_facts = 0;
     }
 
     ~WeightedGrounder() override = default;

--- a/src/search/datalog/grounder/weighted_grounder.h
+++ b/src/search/datalog/grounder/weighted_grounder.h
@@ -43,6 +43,11 @@ class WeightedGrounder : public Grounder {
 
     int queue_pushes;
     int atoms_produced;
+    // Sums over all ground() calls of the search. Unlike the per-call
+    // counters, nothing resets these, so the planner can report one total at
+    // the end of the search.
+    unsigned long long cumulative_atoms_produced;
+    unsigned long long cumulative_queue_pushes;
     int total_number_of_facts;
 
 protected:
@@ -66,6 +71,8 @@ public:
         heuristic_type = h;
         queue_pushes = 0;
         atoms_produced = 0;
+        cumulative_atoms_produced = 0;
+        cumulative_queue_pushes = 0;
         total_number_of_facts = 0;
     }
 
@@ -81,6 +88,14 @@ public:
 
     const std::vector<int> &get_best_achiever_indices() const {
         return best_achievers;
+    }
+
+    unsigned long long get_cumulative_atoms_produced() const {
+        return cumulative_atoms_produced;
+    }
+
+    unsigned long long get_cumulative_queue_pushes() const {
+        return cumulative_queue_pushes;
     }
 
 

--- a/src/search/datalog/grounder/weighted_grounder.h
+++ b/src/search/datalog/grounder/weighted_grounder.h
@@ -56,10 +56,10 @@ class WeightedGrounder : public Grounder {
     // A* for lightest derivations (Felzenszwalb & McAllester): each call
     // computes exact inside/outside costs of the predicate-level abstraction
     // (one node per predicate, one hyperedge per rule) and orders the queue
-    // by f = g (+/max) outside[predicate]. Outside estimates from an
-    // abstraction are admissible and monotone, so the goal still pops at its
-    // exact cost; a predicate with infinite outside cost can never take part
-    // in a goal derivation, so its facts skip the queue entirely.
+    // by f = g + outside[predicate]. Outside estimates from an abstraction
+    // are admissible and monotone, so the goal still pops at its exact cost;
+    // a predicate with infinite outside cost can never take part in a goal
+    // derivation, so its facts skip the queue entirely.
     static constexpr int ABSTRACT_INF = std::numeric_limits<int>::max() / 4;
     std::vector<int> abstract_inside;
     std::vector<int> abstract_outside;
@@ -71,11 +71,13 @@ class WeightedGrounder : public Grounder {
     int priority_of(const Fact &fact) const {
         int pred = fact.get_predicate_index();
         // Goal-less evaluation (static-stratum materialization) computes no
-        // outside costs and runs as a plain Dijkstra.
+        // outside costs and runs as a plain Dijkstra. f = g + outside holds
+        // under both aggregations: chain weights add along a derivation even
+        // under h^max, and the max across a rule's preconditions falls out of
+        // the queue itself, since every fact carries its own f.
         int out = pred < int(abstract_outside.size()) ? abstract_outside[pred] : 0;
         if (out >= ABSTRACT_INF) return ABSTRACT_INF;
-        return (heuristic_type == H_ADD) ? fact.get_cost() + out
-                                         : std::max(fact.get_cost(), out);
+        return fact.get_cost() + out;
     }
 
     // Reused across join() calls so the per-call join key is built in place

--- a/src/search/datalog/grounder/weighted_grounder.h
+++ b/src/search/datalog/grounder/weighted_grounder.h
@@ -53,6 +53,31 @@ class WeightedGrounder : public Grounder {
     // calls (state facts + derived facts only; see num_base_facts).
     phmap::flat_hash_set<Fact> reached_facts;
 
+    // A* for lightest derivations (Felzenszwalb & McAllester): each call
+    // computes exact inside/outside costs of the predicate-level abstraction
+    // (one node per predicate, one hyperedge per rule) and orders the queue
+    // by f = g (+/max) outside[predicate]. Outside estimates from an
+    // abstraction are admissible and monotone, so the goal still pops at its
+    // exact cost; a predicate with infinite outside cost can never take part
+    // in a goal derivation, so its facts skip the queue entirely.
+    static constexpr int ABSTRACT_INF = std::numeric_limits<int>::max() / 4;
+    std::vector<int> abstract_inside;
+    std::vector<int> abstract_outside;
+
+    void compute_abstract_costs(Datalog &datalog,
+                                const std::vector<Fact> &state_facts,
+                                int goal_predicate);
+
+    int priority_of(const Fact &fact) const {
+        int pred = fact.get_predicate_index();
+        // Goal-less evaluation (static-stratum materialization) computes no
+        // outside costs and runs as a plain Dijkstra.
+        int out = pred < int(abstract_outside.size()) ? abstract_outside[pred] : 0;
+        if (out >= ABSTRACT_INF) return ABSTRACT_INF;
+        return (heuristic_type == H_ADD) ? fact.get_cost() + out
+                                         : std::max(fact.get_cost(), out);
+    }
+
     // Reused across join() calls so the per-call join key is built in place
     // instead of allocating a fresh vector every time (join() is the hottest
     // path in the grounder). Same small-buffer-optimized type as JoinHashKey.

--- a/src/search/datalog/rule_matcher.h
+++ b/src/search/datalog/rule_matcher.h
@@ -49,34 +49,29 @@ public:
 
 class RuleMatcher {
     /*
-     Map index of an atom to a vector rule matches
+     * Map predicate index to the rule matches. Predicate indices are small
+     * dense integers, so a flat vector answers the per-pop matcher lookup,
+     * the hottest lookup of the grounder loop, with a single indexed load
+     * where a hash map would pay a hash and a probe per popped fact.
     */
-    phmap::flat_hash_map<int, Matches> rule_matcher;
+    std::vector<Matches> rule_matcher;
 
     static const Matches empty_matches;
-
-    bool atom_has_matched_rules(int i) const {
-        return (rule_matcher.find(i)!=rule_matcher.end());
-    }
 
 public:
     RuleMatcher() = default;
 
-//    explicit RuleMatcher(std::unordered_map<int, Matches> rule_matcher) :
-//        rule_matcher(std::move(rule_matcher)) {}
-
     void insert(int predicate_index, int rule_index, int position) {
-        if (!atom_has_matched_rules(predicate_index)) {
-            rule_matcher[predicate_index] = Matches();
+        if (predicate_index >= int(rule_matcher.size())) {
+            rule_matcher.resize(predicate_index + 1);
         }
         rule_matcher[predicate_index].insert_new_match(rule_index, position);
     }
 
     const Matches &get_matched_rules(int index) const {
-        auto result = rule_matcher.find(index);
-        if (result==rule_matcher.end())
+        if (index >= int(rule_matcher.size()))
             return empty_matches;
-        return result->second;
+        return rule_matcher[index];
     }
 
 };

--- a/src/search/datalog/rules/generic_rule.h
+++ b/src/search/datalog/rules/generic_rule.h
@@ -7,7 +7,9 @@ namespace datalog {
 
 class GenericRule : public RuleBase {
 
-    int schema_index;
+    // Rules created through the inherited constructor have no associated
+    // action schema; -1 makes the annotation generators return no annotation.
+    int schema_index = -1;
 
 public:
     using RuleBase::RuleBase;
@@ -26,7 +28,7 @@ public:
         return GENERIC;
     }
 
-    int get_schema_index() {
+    int get_schema_index() const {
         return schema_index;
     }
 

--- a/src/search/datalog/rules/rule_base.h
+++ b/src/search/datalog/rules/rule_base.h
@@ -183,6 +183,8 @@ public:
 
     std::unique_ptr<Annotation> get_annotation() { return std::move(annotation); }
 
+    bool has_annotation() const { return annotation != nullptr; }
+
     void execute(int head, const Datalog &datalog) const
     {
         if (annotation) {

--- a/src/search/datalog/transformations/remove_equivalent_rules.h
+++ b/src/search/datalog/transformations/remove_equivalent_rules.h
@@ -10,10 +10,24 @@
 #include "../rules/project.h"
 
 #include <set>
+#include <unordered_map>
 
 namespace datalog {
 
 bool Datalog::remove_duplicate_rules() {
+    // Merging predicate q into predicate p (because one rule of each is
+    // equivalent) is only sound if that rule is the *only* rule defining each
+    // of them; otherwise their extensions can differ and rewriting q-atoms
+    // into p-atoms changes the program. All auxiliary predicates the current
+    // transformations introduce have a single defining rule, but the check is
+    // explicit so a future transformation with multi-rule auxiliary
+    // predicates cannot silently miscompile.
+    std::unordered_map<int, int> num_defining_rules;
+    for (const auto &rule : rules) {
+        if (rule->get_effect().is_pred_symbol_new())
+            ++num_defining_rules[rule->get_effect().get_predicate_index()];
+    }
+
     std::vector<size_t> to_be_deleted;
     std::vector<bool> will_be_deleted(rules.size(), false);
     for (size_t i = 0; i < rules.size(); i++) {
@@ -22,11 +36,22 @@ bool Datalog::remove_duplicate_rules() {
         if (!rules[i]->get_effect().is_pred_symbol_new() or will_be_deleted[i])
             continue;
 
+        int predicate_i = rules[i]->get_effect().get_predicate_index();
         for (size_t j = i + 1; j < rules.size(); j++) {
             if (!rules[j]->get_effect().is_pred_symbol_new() or will_be_deleted[j])
                 continue;
-            if (rules[i]->is_equivalent(*rules[j])) {
-                equivalent_to_i.insert(rules[j]->get_effect().get_predicate_index());
+            if (!rules[i]->is_equivalent(*rules[j]))
+                continue;
+            int predicate_j = rules[j]->get_effect().get_predicate_index();
+            if (predicate_j == predicate_i) {
+                // A literal duplicate of rule i is safe to drop without any
+                // predicate replacement.
+                to_be_deleted.emplace_back(j);
+                will_be_deleted[j] = true;
+            }
+            else if (num_defining_rules[predicate_i] == 1 &&
+                     num_defining_rules[predicate_j] == 1) {
+                equivalent_to_i.insert(predicate_j);
                 to_be_deleted.emplace_back(j);
                 will_be_deleted[j] = true;
             }

--- a/src/search/datalog/transformations/static_stratum.h
+++ b/src/search/datalog/transformations/static_stratum.h
@@ -107,7 +107,7 @@ void Datalog::materialize_static_stratum(const Task &task, int heuristic_type) {
     rules = std::move(stratum);
     update_rule_indices();
     {
-        WeightedGrounder grounder(*this, heuristic_type);
+        WeightedGrounder grounder(*this, heuristic_type, true);
         std::vector<Fact> no_state_facts;
         grounder.ground(*this, no_state_facts, -1);
         for (auto &rule : rules) {

--- a/src/search/datalog/transformations/static_stratum.h
+++ b/src/search/datalog/transformations/static_stratum.h
@@ -1,0 +1,134 @@
+#ifndef SEARCH_DATALOG_TRANSFORMATIONS_STATIC_STRATUM_H_
+#define SEARCH_DATALOG_TRANSFORMATIONS_STATIC_STRATUM_H_
+
+#include "../datalog.h"
+
+#include "../grounder/weighted_grounder.h"
+
+#include <unordered_set>
+#include <vector>
+
+namespace datalog {
+
+/*
+ * Materialize the static stratum: this transformation evaluates once, at
+ * initialization, every rule whose extension cannot depend on the state,
+ * moves the derived atoms into the permanent EDB with their weighted costs,
+ * and removes the rules. Every ground() call then starts from the
+ * materialized atoms instead of re-deriving them; profiling showed that the
+ * grounder re-derives the static type-joins of the normal form identically
+ * on every single state evaluation.
+ *
+ * A predicate is *static* iff no state fact can ever reach it. The parser
+ * routes tuples of static task predicates into the static info and never
+ * into states (nullary atoms always live in states, so nullary predicates
+ * count as state-fed), and taint propagates through the rules: a head is
+ * tainted if any body atom's predicate is tainted. To keep the rewrite
+ * exactly behavior-preserving, every materialized rule must also satisfy:
+ * - its head is a new (auxiliary) predicate symbol, because atoms of task
+ *   predicates feed useful_atoms during backchaining and EDB facts do not;
+ * - it carries no annotation, because annotations (e.g. the ff heuristic's
+ *   relaxed-plan extraction) execute during backchaining and backchaining
+ *   never enters EDB facts.
+ * A head with any ineligible rule counts as tainted, so a predicate is
+ * materialized only with its full extension and final costs.
+ *
+ * The weighted grounder itself evaluates the stratum on the reduced rule set
+ * (EDB facts only, no goal), with the same cost aggregation as the consuming
+ * heuristic, so the materialized costs equal the costs the grounder would
+ * have computed per state.
+ */
+void Datalog::materialize_static_stratum(const Task &task, int heuristic_type) {
+    // Taint: predicates whose extension can vary with the state.
+    std::unordered_set<int> tainted;
+    for (size_t i = 0; i < task.predicates.size(); ++i) {
+        if (!task.predicates[i].isStaticPredicate() || task.predicates[i].getArity() == 0) {
+            tainted.insert(i);
+        }
+    }
+    // Heads of rules that may never be materialized taint their predicate.
+    bool any_annotation = false;
+    for (const auto &rule : rules) {
+        if (!rule->get_effect().is_pred_symbol_new() || rule->has_annotation()) {
+            tainted.insert(rule->get_effect().get_predicate_index());
+        }
+        if (rule->has_annotation()) any_annotation = true;
+    }
+    // Annotations (relaxed-plan extraction) recover projected-away variables
+    // by descending into the *achievers* of body atoms marked as indirect in
+    // the variable-source tables. A materialized fact has no achievers, so
+    // any predicate whose sub-derivation that recovery may enter must stay
+    // live.
+    if (any_annotation) {
+        for (const auto &rule : rules) {
+            for (const auto &entry :
+                 rule->get_variable_source_object_by_ref().get_table()) {
+                if (entry.first >= 0 &&
+                    entry.first < int(rule->get_conditions().size())) {
+                    tainted.insert(
+                        rule->get_conditions()[entry.first].get_predicate_index());
+                }
+            }
+        }
+    }
+    bool changed = true;
+    while (changed) {
+        changed = false;
+        for (const auto &rule : rules) {
+            int head = rule->get_effect().get_predicate_index();
+            if (tainted.count(head)) continue;
+            for (const DatalogAtom &b : rule->get_conditions()) {
+                if (tainted.count(b.get_predicate_index())) {
+                    tainted.insert(head);
+                    changed = true;
+                    break;
+                }
+            }
+        }
+    }
+
+    std::vector<std::unique_ptr<RuleBase>> kept;
+    std::vector<std::unique_ptr<RuleBase>> stratum;
+    for (auto &rule : rules) {
+        if (tainted.count(rule->get_effect().get_predicate_index())) {
+            kept.push_back(std::move(rule));
+        }
+        else {
+            stratum.push_back(std::move(rule));
+        }
+    }
+
+    if (stratum.empty()) {
+        rules = std::move(kept);
+        return;
+    }
+
+    // Evaluate the stratum with the engine itself: EDB facts only, no goal.
+    rules = std::move(stratum);
+    update_rule_indices();
+    {
+        WeightedGrounder grounder(*this, heuristic_type);
+        std::vector<Fact> no_state_facts;
+        grounder.ground(*this, no_state_facts, -1);
+        for (auto &rule : rules) {
+            rule->clean_up();
+        }
+    }
+    const size_t num_seed_facts = permanent_edb.size();
+    const size_t num_materialized = facts.size() - num_seed_facts;
+    for (size_t i = num_seed_facts; i < facts.size(); ++i) {
+        const Fact &f = facts[i];
+        permanent_edb.emplace_back(f.get_arguments(), f.get_predicate_index(), f.get_cost(),
+                                   f.is_pred_symbol_new());
+    }
+    reset_facts();
+
+    std::cout << "Materialized static stratum: " << num_materialized << " atoms from "
+              << rules.size() << " rules" << std::endl;
+
+    rules = std::move(kept);
+}
+
+}
+
+#endif //SEARCH_DATALOG_TRANSFORMATIONS_STATIC_STRATUM_H_

--- a/src/search/heuristics/add_heuristic.cc
+++ b/src/search/heuristics/add_heuristic.cc
@@ -22,7 +22,7 @@ int AdditiveHeuristic::compute_heuristic(const DBState &s, const Task &task) {
 
     int h = grounder.ground(datalog, state_facts, datalog.get_goal_atom_idx());
     //grounder.print_statistics(datalog);
-    datalog.reset_facts();
+    // ground() itself truncates the facts to the persistent base.
 
     for (const auto &r : datalog.get_rules())
         r->clean_up();

--- a/src/search/heuristics/add_heuristic.cc
+++ b/src/search/heuristics/add_heuristic.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 AdditiveHeuristic::AdditiveHeuristic(const Task &task, DatalogTransformationOptions opts) :
     datalog(initialize_datalog(task, get_annotation_generator(), opts)),
-    grounder(datalog, datalog::H_ADD) {}
+    grounder(datalog, datalog::H_ADD, true) {}
 
 datalog::AnnotationGenerator AdditiveHeuristic::get_annotation_generator() {
     return [&](int action_schema_id, const Task &task) -> unique_ptr<datalog::Annotation> {

--- a/src/search/heuristics/add_heuristic.h
+++ b/src/search/heuristics/add_heuristic.h
@@ -22,6 +22,13 @@ public:
     AdditiveHeuristic(const Task &task, DatalogTransformationOptions opts);
 
     int compute_heuristic(const DBState &s, const Task &task) override;
+
+    void print_statistics() const override {
+        std::cout << "Total atoms produced by grounder: "
+                  << grounder.get_cumulative_atoms_produced() << std::endl;
+        std::cout << "Total queue pushes by grounder: "
+                  << grounder.get_cumulative_queue_pushes() << std::endl;
+    }
 };
 
 #endif //SEARCH_HEURISTICS_ADD_HEURISTIC_H_

--- a/src/search/heuristics/ff_heuristic.cc
+++ b/src/search/heuristics/ff_heuristic.cc
@@ -36,7 +36,9 @@ public:
 
 FFHeuristic::FFHeuristic(const Task &task, DatalogTransformationOptions opts) :
     datalog(initialize_datalog(task, get_annotation_generator(), opts)),
-    grounder(datalog, datalog::H_ADD) {}
+    // Cost-only queue order: the relaxed plan depends on achiever
+    // tie-breaking, which the outside-cost order would change.
+    grounder(datalog, datalog::H_ADD, false) {}
 
 int FFHeuristic::compute_heuristic(const DBState &s, const Task &task) {
     pi_ff.clear();

--- a/src/search/heuristics/ff_heuristic.cc
+++ b/src/search/heuristics/ff_heuristic.cc
@@ -57,7 +57,7 @@ int FFHeuristic::compute_heuristic(const DBState &s, const Task &task) {
         ff_cost += task.get_action_schema_by_index(action.first).get_cost();
     }
 
-    datalog.reset_facts();
+    // ground() itself truncates the facts to the persistent base.
     for (const auto &r : datalog.get_rules())
         r->clean_up();
     if (h_add == std::numeric_limits<int>::max())

--- a/src/search/heuristics/ff_heuristic.h
+++ b/src/search/heuristics/ff_heuristic.h
@@ -27,6 +27,13 @@ public:
     FFHeuristic(const Task &task, DatalogTransformationOptions opts);
 
     int compute_heuristic(const DBState &s, const Task &task) override;
+
+    void print_statistics() const override {
+        std::cout << "Total atoms produced by grounder: "
+                  << grounder.get_cumulative_atoms_produced() << std::endl;
+        std::cout << "Total queue pushes by grounder: "
+                  << grounder.get_cumulative_queue_pushes() << std::endl;
+    }
 };
 
 #endif //SEARCH_HEURISTICS_FF_HEURISTIC_H_

--- a/src/search/heuristics/heuristic.h
+++ b/src/search/heuristics/heuristic.h
@@ -32,6 +32,11 @@ public:
      */
     virtual int compute_heuristic(const DBState &s, const Task &task) = 0;
 
+    // The planner calls this once after the search finishes; heuristics can
+    // report cumulative statistics here (the grounder-based ones print the
+    // total atoms produced and queue pushes over all ground() calls).
+    virtual void print_statistics() const {}
+
     const std::vector<std::vector<GroundAtom>> &get_useful_atoms() const {
         return useful_atoms;
     }

--- a/src/search/heuristics/hmax_heuristic.cc
+++ b/src/search/heuristics/hmax_heuristic.cc
@@ -6,7 +6,7 @@ using namespace std;
 
 HMaxHeuristic::HMaxHeuristic(const Task &task, DatalogTransformationOptions opts) :
     datalog(initialize_datalog(task, get_annotation_generator(), opts, datalog::H_MAX)),
-    grounder(datalog, datalog::H_MAX) {}
+    grounder(datalog, datalog::H_MAX, true) {}
 
 datalog::AnnotationGenerator HMaxHeuristic::get_annotation_generator() {
     return [&](int action_schema_id, const Task &task) -> unique_ptr<datalog::Annotation> {

--- a/src/search/heuristics/hmax_heuristic.cc
+++ b/src/search/heuristics/hmax_heuristic.cc
@@ -22,7 +22,7 @@ int HMaxHeuristic::compute_heuristic(const DBState &s, const Task &task) {
 
     int h = grounder.ground(datalog, state_facts, datalog.get_goal_atom_idx());
     //grounder.print_statistics(datalog);
-    datalog.reset_facts();
+    // ground() itself truncates the facts to the persistent base.
 
     for (const auto &r : datalog.get_rules())
         r->clean_up();

--- a/src/search/heuristics/hmax_heuristic.cc
+++ b/src/search/heuristics/hmax_heuristic.cc
@@ -5,7 +5,7 @@
 using namespace std;
 
 HMaxHeuristic::HMaxHeuristic(const Task &task, DatalogTransformationOptions opts) :
-    datalog(initialize_datalog(task, get_annotation_generator(), opts)),
+    datalog(initialize_datalog(task, get_annotation_generator(), opts, datalog::H_MAX)),
     grounder(datalog, datalog::H_MAX) {}
 
 datalog::AnnotationGenerator HMaxHeuristic::get_annotation_generator() {

--- a/src/search/heuristics/hmax_heuristic.h
+++ b/src/search/heuristics/hmax_heuristic.h
@@ -22,6 +22,13 @@ public:
     HMaxHeuristic(const Task &task, DatalogTransformationOptions opts);
 
     int compute_heuristic(const DBState &s, const Task &task) override;
+
+    void print_statistics() const override {
+        std::cout << "Total atoms produced by grounder: "
+                  << grounder.get_cumulative_atoms_produced() << std::endl;
+        std::cout << "Total queue pushes by grounder: "
+                  << grounder.get_cumulative_queue_pushes() << std::endl;
+    }
 };
 
 #endif //SEARCH_HEURISTICS_HMAX_HEURISTIC_H_

--- a/src/search/heuristics/rff_heuristic.cc
+++ b/src/search/heuristics/rff_heuristic.cc
@@ -41,7 +41,7 @@ int RFFHeuristic::compute_heuristic(const DBState &s, const Task &task) {
 
     int h_add = grounder.ground(datalog, state_facts, datalog.get_goal_atom_idx());
 
-    datalog.reset_facts();
+    // ground() itself truncates the facts to the persistent base.
     for (const auto &r : datalog.get_rules())
         r->clean_up();
     if (h_add == std::numeric_limits<int>::max())

--- a/src/search/heuristics/rff_heuristic.cc
+++ b/src/search/heuristics/rff_heuristic.cc
@@ -30,7 +30,9 @@ public:
 
 RFFHeuristic::RFFHeuristic(const Task &task, DatalogTransformationOptions opts) :
     datalog(initialize_datalog(task, get_annotation_generator(), opts)),
-    grounder(datalog, datalog::H_ADD) {}
+    // Cost-only queue order: the relaxed plan depends on achiever
+    // tie-breaking, which the outside-cost order would change.
+    grounder(datalog, datalog::H_ADD, false) {}
 
 int RFFHeuristic::compute_heuristic(const DBState &s, const Task &task) {
     if (task.is_goal((s))) return 0;

--- a/src/search/heuristics/rff_heuristic.h
+++ b/src/search/heuristics/rff_heuristic.h
@@ -23,6 +23,13 @@ public:
     RFFHeuristic(const Task &task, DatalogTransformationOptions opts);
 
     int compute_heuristic(const DBState &s, const Task &task) override;
+
+    void print_statistics() const override {
+        std::cout << "Total atoms produced by grounder: "
+                  << grounder.get_cumulative_atoms_produced() << std::endl;
+        std::cout << "Total queue pushes by grounder: "
+                  << grounder.get_cumulative_queue_pushes() << std::endl;
+    }
 };
 
 #endif //SEARCH_HEURISTICS_RFF_HEURISTIC_H_

--- a/src/search/heuristics/utils.cc
+++ b/src/search/heuristics/utils.cc
@@ -2,7 +2,8 @@
 
 datalog::Datalog initialize_datalog(const Task &task,
                                     datalog::AnnotationGenerator annotation_generator,
-                                    const DatalogTransformationOptions &opts) {
+                                    const DatalogTransformationOptions &opts,
+                                    int grounder_type) {
     datalog::Datalog dl(task, annotation_generator);
 
     if (opts.get_remove_action_predicates())
@@ -20,6 +21,7 @@ datalog::Datalog initialize_datalog(const Task &task,
 
     // These transformations are always done too.
     dl.set_permanent_edb(task.get_static_info());
+    dl.materialize_static_stratum(task, grounder_type);
     dl.update_rule_indices();
 
     dl.print_statistics();

--- a/src/search/heuristics/utils.h
+++ b/src/search/heuristics/utils.h
@@ -7,9 +7,13 @@
 
 #include "../datalog/grounder/weighted_grounder.h"
 
+// grounder_type is the cost aggregation (datalog::H_ADD or datalog::H_MAX) of
+// the grounder that will evaluate the program; the static-stratum
+// materialization uses the same aggregation.
 datalog::Datalog initialize_datalog(const Task &task,
                                     datalog::AnnotationGenerator annotation_generator,
-                                    const DatalogTransformationOptions &opts);
+                                    const DatalogTransformationOptions &opts,
+                                    int grounder_type = datalog::H_ADD);
 
 std::vector<datalog::Fact> get_datalog_facts_from_state(const DBState &s, const Task &task);
 

--- a/src/search/main.cc
+++ b/src/search/main.cc
@@ -114,6 +114,7 @@ int main(int argc, char *argv[])
     try {
         auto exitcode = search->search(task, *sgen, *heuristic);
         search->print_statistics();
+        heuristic->print_statistics();
         utils::report_exit_code_reentrant(exitcode);
         return static_cast<int>(exitcode);
     }

--- a/src/search/search_engines/alternated_bfws.cc
+++ b/src/search/search_engines/alternated_bfws.cc
@@ -90,7 +90,7 @@ utils::ExitCode AlternatedBFWS<PackedStateT>::search(const Task &task,
     size_t number_goal_conditions = task.get_goal().goal.size() + task.get_goal().positive_nullary_goals.size() + task.get_goal().negative_nullary_goals.size();
     size_t number_relevant_atoms;
 
-    std::unique_ptr<Heuristic> delete_free_h(HeuristicFactory::create_delete_free_heuristic(heuristic_type, task));
+    delete_free_h.reset(HeuristicFactory::create_delete_free_heuristic(heuristic_type, task));
 
     atom_counter = initialize_counter_with_useful_atoms(task, *delete_free_h);
     number_relevant_atoms = atom_counter.get_total_number_of_atoms();
@@ -228,6 +228,8 @@ template <class PackedStateT>
 void AlternatedBFWS<PackedStateT>::print_statistics() const {
     statistics.print_detailed_statistics();
     space.print_statistics();
+    if (delete_free_h)
+        delete_free_h->print_statistics();
 }
 
 

--- a/src/search/search_engines/alternated_bfws.h
+++ b/src/search/search_engines/alternated_bfws.h
@@ -13,6 +13,8 @@
 #include "../open_lists/tiebreaking_open_list.h"
 #include "../open_lists/greedy_open_list.h"
 
+#include <memory>
+
 #include "../options.h"
 
 template <class PackedStateT>
@@ -22,6 +24,10 @@ class AlternatedBFWS : public SearchBase {
     bool full_novelty_check;
 
     std::string heuristic_type;
+
+    // A member rather than a search() local, so print_statistics() can report
+    // the grounder statistics of the heuristic that evaluated the states.
+    std::unique_ptr<Heuristic> delete_free_h;
 
 protected:
     SearchSpace<PackedStateT> space;

--- a/src/search/search_engines/greedy_best_first_search.cc
+++ b/src/search/search_engines/greedy_best_first_search.cc
@@ -79,29 +79,27 @@ utils::ExitCode GreedyBestFirstSearch<PackedStateT>::search(const Task &task,
             DBState s = generator.generate_successor(op_id, action, state);
             auto& child_node = space.insert_or_get_previous_node(packer.pack(s), op_id, node.state_id);
             int dist = g + action.get_cost();
-            int new_h = heuristic.compute_heuristic(s, task);
-            statistics.inc_evaluations();
-            if (new_h == UNSOLVABLE_STATE) {
-                if (child_node.status == SearchNode::Status::NEW) {
-                    // Only increase statistics for new dead-ends
-                    child_node.open(dist, new_h);
+            if (child_node.status == SearchNode::Status::NEW) {
+                // The search reaches this state for the first time: evaluate
+                // it and memoize the value in the node. The heuristic is a
+                // function of the state alone, so duplicates never need
+                // re-evaluation.
+                int new_h = heuristic.compute_heuristic(s, task);
+                statistics.inc_evaluations();
+                child_node.open(dist, new_h);
+                if (new_h == UNSOLVABLE_STATE) {
                     statistics.inc_dead_ends();
                     statistics.inc_pruned_states();
+                    continue;
                 }
-                continue;
-            }
-
-            if (child_node.status == SearchNode::Status::NEW) {
-                // Inserted for the first time in the map
-                child_node.open(dist, new_h);
                 statistics.inc_evaluated_states();
                 queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
             }
             else {
-                if (dist < child_node.g) {
-                    child_node.open(dist, new_h); // Reopening
+                if (dist < child_node.g && child_node.h != UNSOLVABLE_STATE) {
+                    child_node.open(dist, child_node.h); // Reopening, memoized h
                     statistics.inc_reopened();
-                    queue.do_insertion(child_node.state_id, make_pair(new_h, dist));
+                    queue.do_insertion(child_node.state_id, make_pair(child_node.h, dist));
                 }
             }
         }


### PR DESCRIPTION
Speeds up grounding-based heuristic evaluation with five changes to the weighted grounder and one to greedy best-first search:

- **Materialize the static stratum at initialization** (7242ce0): rules whose extension cannot depend on the state are evaluated once and their atoms moved into the permanent EDB with final costs, instead of being re-derived on every `ground()` call.
- **Persistent base of underivable EDB facts** (537f0af): EDB facts no rule can improve are inserted once and re-pushed by index on later calls, skipping re-copying and re-hashing.
- **Flat-vector rule matcher** (e2d0899): rule matching indexed by predicate through a flat vector instead of hash lookups.
- **Memoize heuristic values for duplicate states in GBFS** (98cad70): duplicates reaching the open list no longer re-ground the Datalog program.
- **A\* queue ordering from a predicate-level abstraction** (ec18b20, 09659b4, b7944a7): each evaluation computes exact inside/outside costs of the predicate abstraction; facts of predicates with infinite outside cost can never take part in a goal derivation and skip the queue, and h^add/h^max additionally order the queue by f = g + outside, which truncates the Dijkstra run while popping the goal at its exact cost. Heuristics that extract achievers (h^ff, h^rff) keep the plain cost order so achiever tie-breaking matches the plain Dijkstra grounder.
- Two small fixes found along the way: unsound predicate merging in `remove_duplicate_rules` (4518b17) and an uninitialized schema index for `GenericRule` (fe8d510).

## Evaluation

Full suite (1,001 IPC + 862 HTG instances, 1800 s / 16 GB), this branch (b7944a7) vs master (9c2f05f). Search-time geomean over instances solved by both with master ≥ 1 s:

| config | coverage | search time |
|---|---|---|
| gbfs, h^add, full_reducer | +64 (none lost) | 0.48 |
| gbfs, h^max, full_reducer | +47 (none lost) | 0.27 |
| gbfs, h^ff, full_reducer | +49 (+62/−13) | 0.58 |
| alt-bfws1, h^ff, yannakakis | +1 (+6/−5) | 0.94 |

Peak memory is 0.97–0.99 across configs.

**Behavior guarantees.** h^add and h^max are bit-identical to master on every instance both revisions solve: zero mismatches in plan cost, expansions, generations, and initial h-value. h^ff stays exact in its costs but records different equally-cheap achievers on ~15% of instances, because the materialized static stratum no longer interleaves with the queue run; the drift is balanced (expansions geomean 0.95 on affected instances, plan costs +1.5% overall with 41 better / 40 worse) and inherent to the materialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
