### PR TITLE
Set predicate symbols in the DBState size constructor

### DIFF
--- a/src/search/states/state.h
+++ b/src/search/states/state.h
@@ -34,7 +34,11 @@ public:
 
     DBState() = default;
     explicit DBState(unsigned num_predicates) :
-        relations(num_predicates), nullary_atoms(num_predicates, false) {}
+        relations(num_predicates), nullary_atoms(num_predicates, false) {
+        for (std::size_t i = 0; i < relations.size(); ++i) {
+            relations[i].predicate_symbol = static_cast<int>(i);
+        }
+    }
 
     DBState(std::vector<Relation> &&relations, std::vector<bool> &&nullary_atoms, int num_objects) :
         relations(std::move(relations)),


### PR DESCRIPTION
Fixes #63.

The `DBState(unsigned num_predicates)` constructor default-constructed its relations, leaving every `predicate_symbol` at 0. It now numbers each relation with its own index, matching the invariant maintained by the other constructors (e.g., `SparseStatePacker::unpack`).

The constructor has no callers inside this repository, so no in-tree behavior changes. The full `dev/run-tests.py` suite passes (62/62).

🤖 Generated with [Claude Code](https://claude.com/claude-code)