### PR TITLE
Key the Datalog action predicates by schema index instead of name

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -20,7 +20,9 @@ correctness regressions quickly before running larger experiments elsewhere.
    These run `bfs` and `gbfs` with the `blind` heuristic on a small set of
    benchmark instances and check the expected plan cost.
 2. Special-case planner paths.
-   These include `clique_bk`, `clique_kckp`, and a small object-creation task.
+   These include `clique_bk`, `clique_kckp`, a small object-creation task, and
+   a disjunctive-precondition task that checks the Datalog heuristics on
+   action schemas split by the translator (issue #64).
 3. Heuristic smoke tests.
    These tests evaluate `goalcount`, `add`, `hmax`, `ff`, and `rff` through `gbfs`
    and require heuristic-evaluation output plus a valid plan.

--- a/dev/domains/disjunction/domain.pddl
+++ b/dev/domains/disjunction/domain.pddl
@@ -1,0 +1,16 @@
+;; Regression domain for issue #64: the translator splits the disjunctive
+;; precondition into three action schemas that all keep the name "doit".
+;; The Datalog-based heuristics must keep the split schemas apart when
+;; building their internal rules.
+(define (domain disjunction)
+  (:requirements :strips :disjunctive-preconditions)
+  (:predicates
+    (p ?x)
+    (q ?x)
+    (r ?x)
+    (g ?x))
+  (:action doit
+    :parameters (?x)
+    :precondition (or (p ?x) (q ?x) (r ?x))
+    :effect (g ?x))
+)

--- a/dev/domains/disjunction/prob01.pddl
+++ b/dev/domains/disjunction/prob01.pddl
@@ -1,0 +1,10 @@
+;; The goal needs two different disjuncts of the split schema: (g a) is only
+;; reachable through the q-disjunct and (g b) only through the r-disjunct.
+;; With the issue #64 name collision, at most one disjunct kept its effects,
+;; so the Datalog heuristics reported this solvable task as unsolvable.
+(define (problem disjunction-01)
+  (:domain disjunction)
+  (:objects a b)
+  (:init (q a) (r b))
+  (:goal (and (g a) (g b)))
+)

--- a/dev/run-tests.py
+++ b/dev/run-tests.py
@@ -51,6 +51,19 @@ SPECIAL_PLAN_TESTS = [
         'configs': [('bfs', 'blind', 'full_reducer')],
     },
     {
+        # Regression test for issue #64: disjunctive preconditions are split
+        # into several action schemas with the same name, and the Datalog
+        # heuristics used to collapse them into a single action predicate.
+        'instance': 'domains/disjunction/prob01.pddl',
+        'label': 'disjunction-prob01',
+        'cost': 2,
+        'validate': True,
+        'configs': [('gbfs', 'add', 'full_reducer'),
+                    ('gbfs', 'hmax', 'full_reducer'),
+                    ('gbfs', 'ff', 'full_reducer'),
+                    ('gbfs', 'rff', 'full_reducer')],
+    },
+    {
         'instance': 'domains/blocks/probBLOCKS-4-0.pddl',
         'label': 'probBLOCKS-4-0-full-novelty',
         'cost': None,

--- a/src/search/datalog/datalog.cc
+++ b/src/search/datalog/datalog.cc
@@ -52,7 +52,11 @@ void Datalog::create_rules(AnnotationGenerator ann) {
 
 void Datalog::generate_action_rule(const ActionSchema &schema,
                                    std::vector<size_t> nullary_preconds, AnnotationGenerator &annotation_generator) {
-    string action_predicate = "action-" + schema.get_name();
+    // Key the auxiliary predicate by schema index: the translator can emit
+    // several schemas with the same name (e.g., split disjunctive
+    // preconditions), and name collisions would wire all their effect rules
+    // to a single action predicate.
+    string action_predicate = "action-" + std::to_string(schema.get_index());
     int idx = get_next_auxiliary_predicate_idx();
     map_new_predicates_to_idx.emplace(action_predicate, idx);
     predicate_names.push_back(action_predicate);
@@ -86,7 +90,7 @@ void Datalog::generate_action_effect_rules(const ActionSchema &schema, Annotatio
 
 vector<DatalogAtom> Datalog::get_action_effect_rule_body(const ActionSchema &schema) {
     vector<DatalogAtom> body(1);
-    string action_predicate = "action-" + schema.get_name();
+    string action_predicate = "action-" + std::to_string(schema.get_index());
     size_t idx = map_new_predicates_to_idx[action_predicate];
     body[0] = DatalogAtom(schema, idx);
     return body;


### PR DESCRIPTION
Fixes #64.

The translator splits disjunctive preconditions into several action schemas that share a name (`normalize.py`, `split_disjunctions`), and their relative order in `output.lifted` varies across runs because `task.actions` is a Python set. On the search side, `Datalog::create_rules` keyed the auxiliary "action predicate" by schema name, and `std::unordered_map::emplace` silently keeps the first entry on a collision. As a result, the effect rules of *all* same-name schemas attached to the first schema's action predicate, and `remove_action_predicates` then dropped the remaining schemas' effects from the program entirely.

The consequences were worse than noisy heuristic values: on a small disjunctive task (now `dev/domains/disjunction/`), `gbfs` with any Datalog-based heuristic (`add`, `hmax`, `ff`, `rff`) reported a solvable task as unsolvable in 13 of 20 runs, and solved it in the other 7, depending on which schema variant happened to win the collision.

The fix keys the action predicate by `schema.get_index()`, which is unique per schema, in both `generate_action_rule` and `get_action_effect_rule_body` (the fix proposed in the issue). The `action-` name is used nowhere else, so nothing depends on the old naming.

Also adds a regression test: `dev/domains/disjunction/prob01.pddl` needs two different disjuncts of the split schema, so the old code fails it deterministically for all four Datalog heuristics. Full `dev/run-tests.py`: 66/66 with the fix, 62/66 without it (exactly the four new tests fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)